### PR TITLE
Add routine to reconnect to server when the server websocket is closed

### DIFF
--- a/pkg/mediationcontainer/mediation_container.go
+++ b/pkg/mediationcontainer/mediation_container.go
@@ -64,8 +64,7 @@ func CreateMediationContainer(containerConfig *MediationContainerConfig) *mediat
 // Start the RemoteMediationClient
 func InitMediationContainer(probeRegisteredMsg chan bool) {
 	theContainer := singletonMediationContainer()
-	//func (theContainer *mediationContainer) Init(probeRegisteredMsg chan bool) {
-	glog.Infof("[MediationContainer] Initializing Mediation Container .....")
+	glog.Infof("Initializing mediation container .....")
 	// Assert that the probes are registered before starting the handshake
 	if len(theContainer.allProbes) == 0 {
 		glog.Errorf("No probes are registered with the container")
@@ -78,15 +77,15 @@ func InitMediationContainer(probeRegisteredMsg chan bool) {
 	remoteMediationClient.Init(probeRegisteredMsg)
 }
 
-func (theContainer *mediationContainer) Close() {
+func CloseMediationContainer() {
+	glog.Infof("[CloseMediationContainer] Closing mediation container .....")
+	theContainer := singletonMediationContainer()
 	theContainer.theRemoteMediationClient.Stop()
 	// TODO: clear probe map ?
 }
 
 // ============================= Probe Management ==================
 func LoadProbe(probe *probe.TurboProbe) error {
-	//func (theContainer *mediationContainer) LoadProbe(probe *probe.TurboProbe)
-
 	// load the probe config
 	config := &ProbeSignature{
 		ProbeCategory: probe.ProbeCategory,
@@ -99,7 +98,7 @@ func LoadProbe(probe *probe.TurboProbe) error {
 	}
 	theContainer := singletonMediationContainer()
 	if theContainer == nil {
-		return errors.New("[LoadProbe] **** Null mediation container ****")
+		return errors.New("[LoadProbe] Null mediation container")
 	}
 	// TODO: check if the probe type already exists and warn before overwriting
 	theContainer.allProbes[config.ProbeType] = probeProp
@@ -110,7 +109,7 @@ func LoadProbe(probe *probe.TurboProbe) error {
 func GetProbe(probeType string) (*probe.TurboProbe, error) {
 	theContainer := singletonMediationContainer()
 	if theContainer == nil {
-		return nil, errors.New("[GetProbe] **** Null mediation container ****")
+		return nil, errors.New("[GetProbe] Null mediation container")
 	}
 	probeProps := theContainer.allProbes[probeType]
 

--- a/pkg/mediationcontainer/transport_endpoint.go
+++ b/pkg/mediationcontainer/transport_endpoint.go
@@ -1,17 +1,21 @@
 package mediationcontainer
 
-
 // Transport endpoint that sends and receives raw message bytes
 type ITransport interface {
+	// Open
+	Connect() error
+	GetConnectionId() string
+	// Send
+	Send(messageToSend *TransportMessage) error
+	// Receive
+	ListenForMessages()
+	RawMessageReceiver() chan []byte // Queue or channel for putting byte[] received on the transport
+	StopListenForMessages()
+	// Close
 	CloseTransportPoint()
-	Send(messageToSend *TransportMessage)
-	RawMessageReceiver() chan []byte
+	NotifyClosed() chan bool // Channel where connection closed notification is sent
 }
 
 type TransportMessage struct {
 	RawMsg []byte
 }
-
-//type TransportMessage []byte
-
-

--- a/pkg/probe/turbo_probe.go
+++ b/pkg/probe/turbo_probe.go
@@ -106,6 +106,7 @@ func (theProbe *TurboProbe) DiscoverTarget(accountValues []*proto.AccountValue) 
 		discoveryResponse = theProbe.createDiscoveryErrorDTO(description, severity)
 		glog.Errorf("Error discovering target %s", discoveryResponse)
 	}
+	glog.V(2).Infof("Discovery response : %s", discoveryResponse)
 	return discoveryResponse
 }
 

--- a/pkg/proto/proto_version_const.go
+++ b/pkg/proto/proto_version_const.go
@@ -1,6 +1,8 @@
 package proto
 
-
+// Remote Mediation Clients are expected to send the protobuf message version to ensure compatibility with the server.
+// This version string is sent as part of the registration protocol in the Negotiation message. Only if the version is
+// accepted by the server then the client probes are allowed to register with the server
 const (
 	PROTOBUF_VERSION string = "5.9.0-SNAPSHOT"
 )


### PR DESCRIPTION
- Try to connect to server websocket until connected by retrying every 30 seconds. Todo: read the connection retry interval from the config file.
- New routine that is waiting for closed/error notification from the underlying transport point and will  try websocket reconnect and perform sdk client protocol 
- Ability to stop the listener routines for the ClientWebSocketTransport and ClientProtobufEndpoint
- Ability for a TAP service to disconnect from turbo server 