### PR TITLE
Updated Logging level and Dependency to Go API

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -29,11 +29,11 @@
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-api/pkg/api",
-			"Rev": "ab4115ac92988711b0cb796ada1ccef762a5a5db"
+			"Rev": "fd14e63608358e8893e0b7d9ff05fdf217a7315b"
 		},
 		{
 			"ImportPath": "github.com/turbonomic/turbo-api/pkg/client",
-			"Rev": "ab4115ac92988711b0cb796ada1ccef762a5a5db"
+			"Rev": "fd14e63608358e8893e0b7d9ff05fdf217a7315b"
 		},
 		{
 			"ImportPath": "golang.org/x/net/websocket",

--- a/pkg/mediationcontainer/client_protobuf_endpoint.go
+++ b/pkg/mediationcontainer/client_protobuf_endpoint.go
@@ -1,9 +1,10 @@
 package mediationcontainer
 
 import (
+	"time"
+
 	"github.com/golang/glog"
 	goproto "github.com/golang/protobuf/proto"
-	"time"
 )
 
 // =====================================================================================================
@@ -16,23 +17,23 @@ type ClientProtobufEndpoint struct {
 	// Parser for the message - this will vary with the type of message communication the endpoint is being used for
 	messageHandler ProtobufMessage
 	// Channel where the endpoint will send the parsed messages
-	ParsedMessageChannel chan *ParsedMessage// unbuffered channel
+	ParsedMessageChannel chan *ParsedMessage // unbuffered channel
 	// TODO: add message waiting policy
 	stopMsgWaitCh chan bool // buffered channel
 }
 
 // Create a new instance of the ClientProtobufEndpoint that handles communication
 // for a specific message type using the given transport point
-func CreateClientProtobufEndpoint(name string, transport ITransport, messageHandler ProtobufMessage, singleMessageMode bool) ProtobufEndpoint {
+func CreateClientProtoBufEndpoint(name string, transport ITransport, messageHandler ProtobufMessage, singleMessageMode bool) ProtobufEndpoint {
 	endpoint := &ClientProtobufEndpoint{
-		Name: name,
-		transport:      transport, // the transport
+		Name:                 name,
+		transport:            transport, // the transport
 		ParsedMessageChannel: make(chan *ParsedMessage),
-		messageHandler: messageHandler, // the message parser
-		singleMessageMode: singleMessageMode,
+		messageHandler:       messageHandler, // the message parser
+		singleMessageMode:    singleMessageMode,
 	}
 
-	glog.Infof("Created Protobuf Endpoint " + endpoint.GetName())
+	glog.V(3).Infof("Created Protobuf Endpoint " + endpoint.GetName())
 	// Start a Message Handling routine to wait for messages arriving on the transport point
 	if singleMessageMode {
 		endpoint.ParsedMessageChannel = make(chan *ParsedMessage, 1)
@@ -63,18 +64,18 @@ func (endpoint *ClientProtobufEndpoint) GetMessageHandler() ProtobufMessage {
 }
 
 func (endpoint *ClientProtobufEndpoint) CloseEndpoint() {
-	glog.Infof("[" + endpoint.Name + "] : closing endpoint and listener routine")
+	glog.V(4).Infof("[" + endpoint.Name + "] : closing endpoint and listener routine")
 	// Send close to the listener routine
 	if endpoint.stopMsgWaitCh != nil {
-		glog.Infof("["+endpoint.Name+"] closing stopMsgWaitCh %+v", endpoint.stopMsgWaitCh)
+		glog.V(4).Infof("["+endpoint.Name+"] closing stopMsgWaitCh %+v", endpoint.stopMsgWaitCh)
 		endpoint.stopMsgWaitCh <- true
 		close(endpoint.stopMsgWaitCh)
-		glog.Infof("["+endpoint.Name+"] closed stopMsgWaitCh %+v", endpoint.stopMsgWaitCh)
+		glog.V(4).Infof("["+endpoint.Name+"] closed stopMsgWaitCh %+v", endpoint.stopMsgWaitCh)
 	}
 }
 
 func (endpoint *ClientProtobufEndpoint) Send(messageToSend *EndpointMessage) {
-	glog.Infof("[" + endpoint.Name + "] : Sending protobuf message") // %s", messageToSend.ProtobufMessage)
+	glog.V(4).Infof("[%s] : Sending protobuf message", endpoint.Name) // %s", messageToSend.ProtobufMessage)
 	// Marshal protobuf message to raw bytes
 	msgMarshalled, err := goproto.Marshal(messageToSend.ProtobufMessage) // marshal to byte array
 	if err != nil {
@@ -94,23 +95,21 @@ func (endpoint *ClientProtobufEndpoint) Send(messageToSend *EndpointMessage) {
 
 func (endpoint *ClientProtobufEndpoint) waitForServerMessage() {
 
-	logPrefix := "["+endpoint.Name+"][[waitForServerMessage] : "
-	glog.V(2).Infof(logPrefix + " %s : ENTER  ", time.Now())
+	logPrefix := "[" + endpoint.Name + "][[waitForServerMessage] : "
+	glog.V(4).Infof(logPrefix+" %s: ENTER  ", time.Now())
 
 	go func() {
 		// main loop for listening server message until its message receiver channel is closed.
 		for {
-			glog.V(2).Infof("[" + endpoint.Name + "][waitForServerMessage] : waiting for server request at endpoint %s", endpoint)
+			glog.V(4).Infof("["+endpoint.Name+"][waitForServerMessage] : waiting for server request at endpoint %v", endpoint)
 			select {
 			case <-endpoint.stopMsgWaitCh:
-				glog.Infof(logPrefix + " Exit routine *************")
-				glog.Infof(logPrefix + " closing MessageChannel %+v", endpoint.ParsedMessageChannel)
-				close(endpoint.ParsedMessageChannel)	// This listener routine is the writer for this channel
-				glog.Infof(logPrefix + " closed MessageChannel %+v", endpoint.ParsedMessageChannel)
+				glog.V(4).Infof(logPrefix+" closing MessageChannel %+v", endpoint.ParsedMessageChannel)
+				close(endpoint.ParsedMessageChannel) // This listener routine is the writer for this channel
+				glog.V(4).Infof(logPrefix+" closed MessageChannel %+v", endpoint.ParsedMessageChannel)
 				return
 			//default:
 			case rawBytes, ok := <-endpoint.transport.RawMessageReceiver(): // block till  the message bytes from the transport channel,
-
 				// Get the message bytes from the transport channel,
 				// - this will block till the message appears on the channel
 				//rawBytes, ok := <-endpoint.transport.RawMessageReceiver()
@@ -127,7 +126,7 @@ func (endpoint *ClientProtobufEndpoint) waitForServerMessage() {
 					continue
 				}
 
-				glog.V(2).Infof(logPrefix + "received: %s\n", parsedMsg)
+				glog.V(3).Infof(logPrefix+"received: %++v\n", parsedMsg)
 
 				// Put the parsed message on the endpoint's channel
 				// - this will block till the upper layer receives this message
@@ -136,16 +135,16 @@ func (endpoint *ClientProtobufEndpoint) waitForServerMessage() {
 					msgChannel <- parsedMsg
 				}
 
-				glog.Infof(logPrefix + "parsed message delivered on the message channel, continue to listen from transport ...")
+				glog.V(3).Infof(logPrefix + "parsed message delivered on the message channel, continue to listen from transport ...")
 			} //end select
 		} //end for
 	}()
-	glog.Infof(logPrefix + "DONE")
+	glog.V(4).Infof(logPrefix + "DONE")
 }
 
 func (endpoint *ClientProtobufEndpoint) waitForSingleServerMessage() {
-	logPrefix := "["+endpoint.Name+"][[waitForSingleServerMessage] : "
-	glog.Infof(logPrefix + "waiting for server response")
+	logPrefix := "[" + endpoint.Name + "][[waitForSingleServerMessage] : "
+	glog.V(4).Infof(logPrefix + "waiting for server response")
 
 	go func() {
 
@@ -156,22 +155,21 @@ func (endpoint *ClientProtobufEndpoint) waitForSingleServerMessage() {
 		messageHandler := endpoint.GetMessageHandler()
 		parsedMsg, err := messageHandler.parse(rawBytes)
 
-	if err != nil {
-		glog.Errorf("["+endpoint.Name+"][waitForSingleServerMessage] : Received null message, dropping it")
-		parsedMsg = &ParsedMessage{}	//create empty message
-	}
+		if err != nil {
+			glog.Errorf("[" + endpoint.Name + "][waitForSingleServerMessage] : Received null message, dropping it")
+			parsedMsg = &ParsedMessage{} //create empty message
+		}
 
-	glog.Infof("["+endpoint.Name+"][waitForSingleServerMessage] : Received: %s\n", parsedMsg)
+		glog.V(4).Infof("["+endpoint.Name+"][waitForSingleServerMessage] : Received: %s\n", parsedMsg)
 
-	// - this will block till the upper layer receives this message
-	msgChannel := endpoint.MessageReceiver()
-	if msgChannel != nil { // checking if the channel was closed before putting the message
-		msgChannel <- parsedMsg
-	}
+		// - this will block till the upper layer receives this message
+		msgChannel := endpoint.MessageReceiver()
+		if msgChannel != nil { // checking if the channel was closed before putting the message
+			msgChannel <- parsedMsg
+		}
 
-
-		glog.Infof(logPrefix + "parsed message delivered on the message channel")
-		glog.Infof(logPrefix + "DONE")
+		glog.V(4).Infof(logPrefix + "parsed message delivered on the message channel")
+		glog.V(4).Infof(logPrefix + "DONE")
 	}()
 }
 
@@ -202,7 +200,7 @@ func (messageWaiter *ContinuousMessageWaiter) getMessage(endpoint ProtobufEndpoi
 }
 
 func getSingleMessage(endpoint ProtobufEndpoint) {
-	glog.Infof("[" + endpoint.GetName() + "][waitForSingleServerMessage]: ########## Waiting for server request #######")
+	glog.V(4).Infof("[" + endpoint.GetName() + "][waitForSingleServerMessage]: ########## Waiting for server request #######")
 	// listen for server message
 	// - this will block till the message appears on the channel
 	transport := endpoint.GetTransport()
@@ -213,11 +211,11 @@ func getSingleMessage(endpoint ProtobufEndpoint) {
 	messageHandler := endpoint.GetMessageHandler()
 	parsedMsg, err := messageHandler.parse(rawBytes)
 	if err != nil {
-		glog.Errorf("["+endpoint.GetName() +"][SingleMessageWaiter] : Received null message, dropping it")
-		parsedMsg = &ParsedMessage{}	//create empty message
+		glog.Errorf("[" + endpoint.GetName() + "][SingleMessageWaiter] : Received null message, dropping it")
+		parsedMsg = &ParsedMessage{} //create empty message
 	}
 
-	glog.Infof("["+endpoint.GetName()+"][waitForSingleServerMessage] : Received: %s\n", parsedMsg)
+	glog.V(4).Infof("["+endpoint.GetName()+"][waitForSingleServerMessage] : Received: %s\n", parsedMsg)
 
 	// - this will block till the upper layer receives this message
 	msgChannel := endpoint.MessageReceiver()

--- a/pkg/mediationcontainer/mediation_communication_config.go
+++ b/pkg/mediationcontainer/mediation_communication_config.go
@@ -3,9 +3,9 @@ package mediationcontainer
 import (
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/golang/glog"
-	"net/url"
 )
 
 const (

--- a/pkg/mediationcontainer/mediation_communication_config_test.go
+++ b/pkg/mediationcontainer/mediation_communication_config_test.go
@@ -2,9 +2,9 @@ package mediationcontainer
 
 import (
 	"testing"
+	"reflect"
 
 	"github.com/turbonomic/turbo-go-sdk/util/rand"
-	"reflect"
 )
 
 func TestValidateServerMeta(t *testing.T) {

--- a/pkg/mediationcontainer/protobuf_endpoint.go
+++ b/pkg/mediationcontainer/protobuf_endpoint.go
@@ -1,12 +1,13 @@
 package mediationcontainer
 
 import (
-	"github.com/golang/glog"
-	goproto "github.com/golang/protobuf/proto"
+	"fmt"
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"github.com/turbonomic/turbo-go-sdk/pkg/version"
-	"fmt"
+
+	"github.com/golang/glog"
+	goproto "github.com/golang/protobuf/proto"
 )
 
 // Endpoint to handle communication of a particular protobuf message type with the server
@@ -56,7 +57,6 @@ func (sr *MediationRequest) GetMessage() goproto.Message {
 }
 
 func (sr *MediationRequest) parse(rawMsg []byte) (*ParsedMessage, error) {
-	glog.V(2).Infof("Parsing %s\n", rawMsg)
 	// Parse the input stream
 	serverMsg := &proto.MediationServerMessage{}
 	err := goproto.Unmarshal(rawMsg, serverMsg)
@@ -81,7 +81,7 @@ func (nr *NegotiationResponse) parse(rawMsg []byte) (*ParsedMessage, error) {
 	serverMsg := &version.NegotiationAnswer{}
 	err := goproto.Unmarshal(rawMsg, serverMsg)
 	if err != nil {
-		glog.Error("[NegotiationResponse] unmarshaling error: ", err)
+		glog.Errorf("[NegotiationResponse] unmarshaling error: %s", err)
 		return nil, fmt.Errorf("[NegotiationResponse] Error unmarshalling transport input stream to protobuf message : %s", err)
 	}
 	nr.NegotiationMsg = serverMsg
@@ -96,7 +96,7 @@ func (rr *RegistrationResponse) GetMessage() goproto.Message {
 }
 
 func (rr *RegistrationResponse) parse(rawMsg []byte) (*ParsedMessage, error) {
-	glog.V(2).Infof("Parsing %s\n", rawMsg)
+	glog.V(3).Infof("Parsing %s\n", rawMsg)
 	// Parse the input stream
 	serverMsg := &proto.Ack{}
 	err := goproto.Unmarshal(rawMsg, serverMsg)

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -24,12 +24,12 @@ type TAPService struct {
 }
 
 func (tapService *TAPService) DisconnectFromTurbo() {
-	glog.Infof("[DisconnectFromTurbo] Enter *******")
+	glog.V(4).Infof("[DisconnectFromTurbo] Enter *******")
 	close(tapService.disconnectFromTurbo)
-	glog.Infof("[DisconnectFromTurbo] End *********")
+	glog.V(4).Infof("[DisconnectFromTurbo] End *********")
 }
 func (tapService *TAPService) ConnectToTurbo() {
-	glog.Infof("[ConnectToTurbo] Enter ******* ")
+	glog.V(4).Infof("[ConnectToTurbo] Enter ******* ")
 	IsRegistered := make(chan bool, 1)
 
 	// start a separate go routine to connect to the Turbo server
@@ -42,14 +42,15 @@ func (tapService *TAPService) ConnectToTurbo() {
 		glog.Infof("Probe " + tapService.ProbeCategory + "::" + tapService.ProbeType + " is not registered")
 		return
 	}
-	glog.Infof("Probe " + tapService.ProbeCategory + "::" + tapService.ProbeType + " Registered : === Add Targets ===")
+	glog.V(3).Infof("Probe " + tapService.ProbeCategory + "::" + tapService.ProbeType + " Registered : === Add Targets ===")
 	targetInfos := tapService.GetProbeTargets()
 	for _, targetInfo := range targetInfos {
 		target := targetInfo.GetTargetInstance()
 		glog.V(4).Infof("Now adding target %v", target)
 		resp, err := tapService.AddTarget(target)
 		if err != nil {
-			glog.Errorf("Error while adding target %v: %s", targetInfo, err)
+			glog.Errorf("Error while adding %s %s target: %s", targetInfo.TargetCategory(),
+				targetInfo.TargetType(), err)
 			// TODO, do we want to return an error?
 			continue
 		}
@@ -57,7 +58,7 @@ func (tapService *TAPService) ConnectToTurbo() {
 	}
 
 	close(IsRegistered)
-	glog.Infof("[ConnectToTurbo] End ******")
+	glog.V(4).Infof("[ConnectToTurbo] End ******")
 
 	// Once connected the mediation container will keep running till a disconnect message is sent to the tap service
 	tapService.disconnectFromTurbo = make(chan struct{})

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
 	"crypto/tls"
+	"errors"
+
 	"github.com/turbonomic/turbo-api/pkg/api"
 )
 
@@ -15,36 +16,34 @@ type Client struct {
 
 // Create a Turbo API Client based on basic authentication.
 func NewAPIClientWithBA(c *Config) (*Client, error) {
-	if c.BasicAuth == nil {
-		return nil, fmt.Errorf("Basic authentication is not set")
+	if c.basicAuth == nil {
+		return nil, errors.New("Basic authentication is not set")
 	}
 	client := http.DefaultClient
 	// If use https, disable the security check.
-	if c.ServerAddress.Scheme == "https" {
+	if c.serverAddress.Scheme == "https" {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		client = &http.Client{Transport: tr}
 	}
-	restClient := NewRESTClient(client, c.ServerAddress, c.APIPath).BasicAuthentication(c.BasicAuth)
+	restClient := NewRESTClient(client, c.serverAddress, c.apiPath).BasicAuthentication(c.basicAuth)
 	return &Client{restClient}, nil
 }
 
 // Discover a target using API
-// <turbo_server_address>/vmturbo/api/targets/<uuid>
 func (c *Client) DiscoverTarget(uuid string) (*Result, error) {
 	response, err := c.Post().Resource(api.Resource_Type_Target).Name(uuid).Do()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to discover target %s: %s", uuid, err)
 	}
 	if response.statusCode != 200 {
-		return nil, fmt.Errorf("Unsuccessful discovery response: %v", response)
+		return nil, fmt.Errorf("Unsuccessful discovery response: %s", response.status)
 	}
 	return &response, nil
 }
 
-// Add a target using API.
-// <turbo_server_address>/vmturbo/rest/targets
+//Add a target usign API
 func (c *Client) AddTarget(target *api.Target) (*Result, error) {
 	targetData, err := json.Marshal(target)
 	if err != nil {
@@ -59,7 +58,7 @@ func (c *Client) AddTarget(target *api.Target) (*Result, error) {
 		return nil, fmt.Errorf("Failed to add target: %s", err)
 	}
 	if response.statusCode != 200 {
-		return nil, fmt.Errorf("Unsuccessful target addition response: %v", response)
+		return nil, fmt.Errorf("Unsuccessful target addition response: %s", response.status)
 	}
 	return &response, nil
 }

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/config.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/config.go
@@ -5,17 +5,17 @@ import (
 )
 
 const (
-	defaultAPIPath = "vmturbo/api/"
+	defaultAPIPath = "vmturbo/rest/"
 )
 
 type Config struct {
-	// ServerAddress is  a string, which must be a host:port pair.
-	ServerAddress *url.URL
+	// ServerAddress is A URL, including <Scheme>://<IP>:<Port>.
+	serverAddress *url.URL
 	// APIPath is a sub-path that points to an API root.
-	APIPath string
+	apiPath       string
 
-	// For Basic authentication
-	BasicAuth *BasicAuthentication
+	// For Basic authentication.
+	basicAuth     *BasicAuthentication
 }
 
 type ConfigBuilder struct {
@@ -45,14 +45,14 @@ func (cb *ConfigBuilder) BasicAuthentication(usrn, passd string) *ConfigBuilder 
 
 func (cb *ConfigBuilder) Create() *Config {
 	return &Config{
-		ServerAddress: cb.serverAddress,
+		serverAddress: cb.serverAddress,
 		// If API path not specified, use the default API path.
-		APIPath: func() string {
+		apiPath: func() string {
 			if cb.apiPath == "" {
 				return defaultAPIPath
 			}
 			return cb.apiPath
 		}(),
-		BasicAuth: cb.basicAuth,
+		basicAuth: cb.basicAuth,
 	}
 }

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/request.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/request.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -41,6 +42,7 @@ type Request struct {
 
 type Result struct {
 	statusCode int
+	status     string
 	body       string
 	err        error
 }
@@ -69,7 +71,7 @@ func (r *Request) Resource(resource api.ResourceType) *Request {
 	}
 
 	if r.resource != "" {
-		r.err = fmt.Errorf("Resource has already been set. Cannot be changed!")
+		r.err = errors.New("Resource has already been set. Cannot be changed!")
 		return r
 	}
 	r.resource = resource
@@ -86,7 +88,7 @@ func (r *Request) Name(resourceName string) *Request {
 		return r
 	}
 	if len(resourceName) == 0 {
-		r.err = fmt.Errorf("Resource name cannot be empty.")
+		r.err = errors.New("Resource name cannot be empty.")
 		return r
 	}
 	r.resourceName = resourceName
@@ -175,7 +177,6 @@ func (r *Request) request(fn func(*http.Response)) error {
 
 	url := r.URL().String()
 	glog.V(4).Infof("The request url is %s", url)
-	fmt.Printf("The request url is %s\n", url)
 	req, err := http.NewRequest(r.verb, url, r.data)
 	if err != nil {
 		return err
@@ -203,7 +204,7 @@ func (r *Request) request(fn func(*http.Response)) error {
 func parseHTTPResponse(resp *http.Response) Result {
 	if resp == nil {
 		return Result{
-			err: fmt.Errorf("response sent in is nil"),
+			err: errors.New("response sent in is nil"),
 		}
 	}
 
@@ -216,6 +217,7 @@ func parseHTTPResponse(resp *http.Response) Result {
 
 	return Result{
 		statusCode: resp.StatusCode,
+		status:     resp.Status,
 		body:       string(content),
 		err:        nil,
 	}


### PR DESCRIPTION
One bug has also been fixed. Inside [remote_mediation_client.go -> Init()](https://github.com/turbonomic/turbo-go-sdk/compare/master...DongyiYang:logging?expand=1#diff-3cf7d015404469ef5a531d99138fda0dL110), the default case for the select would make the for loop to be an infinite loop without waiting or being block. I've deleted the default case. 