### PR TITLE
Fix Reconnect Failure

### DIFF
--- a/pkg/mediationcontainer/client_websocket_transport_test.go
+++ b/pkg/mediationcontainer/client_websocket_transport_test.go
@@ -73,3 +73,27 @@ func TestCreateClientWebSocketTransport(t *testing.T) {
 		}
 	}
 }
+
+// Test the status changes after function call.
+func TestCloseAndResetWebSocket(t *testing.T) {
+	table := []struct {
+		currStatus TransportStatus
+	}{
+		{
+			currStatus:Closed,
+		},
+		{
+			currStatus:Ready,
+		},
+	}
+
+	for _, item:= range table {
+		// A fake WebSocket transport only for testing status change.
+		fakeWebSocketTransport := &ClientWebSocketTransport{}
+		fakeWebSocketTransport.status = item.currStatus
+		fakeWebSocketTransport.closeAndResetWebSocket()
+		if fakeWebSocketTransport.status != Closed {
+			t.Errorf("Expected status is %s, got %s", Closed, fakeWebSocketTransport.status)
+		}
+	}
+}

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -81,8 +81,6 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 				return
 			case <-transport.NotifyClosed():
 				glog.V(2).Infof("[Reconnect] transport endpoint is closed, starting reconnect ...")
-				// stop transport layer message listener
-				transport.StopListenForMessages()
 
 				// stop server messages listener
 				remoteMediationClient.stopMessageHandler()

--- a/pkg/mediationcontainer/transport_endpoint.go
+++ b/pkg/mediationcontainer/transport_endpoint.go
@@ -10,7 +10,6 @@ type ITransport interface {
 	// Receive
 	ListenForMessages()
 	RawMessageReceiver() chan []byte // Queue or channel for putting byte[] received on the transport
-	StopListenForMessages()
 	// Close
 	CloseTransportPoint()
 	NotifyClosed() chan bool // Channel where connection closed notification is sent


### PR DESCRIPTION
Create [status](https://github.com/turbonomic/turbo-go-sdk/compare/master...DongyiYang:ReconnectFix?expand=1#diff-ab2326914686a36993657f52e15b6884R51) field in ClientWebSocketTransport to indicate the current transport layer status.

closeAndResetWebSocket, stopListenForMessages immediately if there is an error during WebSocket receive, as reconnect gets notified everytime. Changes are [here](https://github.com/turbonomic/turbo-go-sdk/compare/master...DongyiYang:ReconnectFix?expand=1#diff-ab2326914686a36993657f52e15b6884R169).
