### PR TITLE
Update TestBuildCommodityBoughtFromMap

### DIFF
--- a/pkg/builder/entity_dto_builder_test.go
+++ b/pkg/builder/entity_dto_builder_test.go
@@ -409,30 +409,44 @@ func TestBuildCommodityBoughtFromMap(t *testing.T) {
 			}
 		}
 
-		var expectedCommoditiesBought []*proto.EntityDTO_CommodityBought
+		expectedCommoditiesBought := make(map[string]*proto.EntityDTO_CommodityBought)
 		if item.providerCount > 0 {
 			if item.provider1 != "" {
-				expectedCommoditiesBought = append(expectedCommoditiesBought,
+				expectedCommoditiesBought[item.provider1] =
 					&proto.EntityDTO_CommodityBought{
 						ProviderId: &item.provider1,
 						Bought:     item.commodity1,
-					})
+					}
 			}
 			if item.provider2 != "" {
-				expectedCommoditiesBought = append(expectedCommoditiesBought,
+				expectedCommoditiesBought[item.provider2] =
 					&proto.EntityDTO_CommodityBought{
 						ProviderId: &item.provider2,
 						Bought:     item.commodity2,
-					})
+					}
 			}
 		}
 
 		gotCommoditiesBought := buildCommodityBoughtFromMap(inputMap)
-		if !reflect.DeepEqual(expectedCommoditiesBought, gotCommoditiesBought) {
-			t.Errorf("Test case %d failed. Expected: %++v, got %++v", i, expectedCommoditiesBought,
-				gotCommoditiesBought)
+		for _, commBought := range gotCommoditiesBought {
+			found := false
+			if expectedComm, exists := expectedCommoditiesBought[commBought.GetProviderId()]; exists {
+				if !reflect.DeepEqual(expectedComm, commBought) {
+					t.Errorf("Test case %d failed. Expected %++v, got %++v", i,
+						expectedComm, commBought)
+					continue
+				}
+				found = true
+				delete(expectedCommoditiesBought, commBought.GetProviderId())
+			}
+			if !found {
+				t.Errorf("Test case %d failed. Unexpected commodity bought %++v", i, commBought)
+			}
 		}
-
+		if len(expectedCommoditiesBought) != 0 {
+			t.Errorf("Test case %d failed. Expected commodities bought %++v NOT found.", i,
+				expectedCommoditiesBought)
+		}
 	}
 }
 


### PR DESCRIPTION
The unit test TestBuildCommodityBoughtFromMap fails occasionally as here we compare two slice, the order difference fails the test. 
This is because in [buildCommodityBoughtFromMap](https://github.com/turbonomic/turbo-go-sdk/blob/776040894a9cb62f9ec74e5b465ef52c2076816c/pkg/builder/entity_dto_builder.go#L279) we built the result slice from a map while the order of the keys in map cannot be guaranteed.
So here I changed the expectedCommoditiesBought from a slice to map, with key providerID and value commodityBought. Then it uses this map to compare against the actually got commoditiesBought.