### PR TITLE
Expose Version As A Parameter

### DIFF
--- a/pkg/mediationcontainer/mediation_communication_config.go
+++ b/pkg/mediationcontainer/mediation_communication_config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-go-sdk/pkg/version"
 )
 
 const (
@@ -17,6 +18,7 @@ const (
 
 type ServerMeta struct {
 	TurboServer string `json:"turboServer,omitempty"`
+	Version     string `json:"version,omitempty"`
 }
 
 func (meta *ServerMeta) ValidateServerMeta() error {
@@ -25,6 +27,9 @@ func (meta *ServerMeta) ValidateServerMeta() error {
 	}
 	if _, err := url.ParseRequestURI(meta.TurboServer); err != nil {
 		return fmt.Errorf("Invalid turbo address url: %v", meta)
+	}
+	if meta.Version == "" {
+		meta.Version = string(version.PROTOBUF_VERSION)
 	}
 	return nil
 }

--- a/pkg/mediationcontainer/mediation_communication_config_test.go
+++ b/pkg/mediationcontainer/mediation_communication_config_test.go
@@ -1,17 +1,18 @@
 package mediationcontainer
 
 import (
-	"testing"
 	"reflect"
+	"testing"
 
+	"github.com/turbonomic/turbo-go-sdk/pkg/version"
 	"github.com/turbonomic/turbo-go-sdk/util/rand"
 )
 
 func TestValidateServerMeta(t *testing.T) {
 	table := []struct {
 		turboServer string
-
-		expectErr bool
+		version     string
+		expectErr   bool
 	}{
 		{
 			turboServer: "",
@@ -22,13 +23,19 @@ func TestValidateServerMeta(t *testing.T) {
 			expectErr:   false,
 		},
 		{
+			turboServer: "https://localhost:8080",
+			version:     "random",
+			expectErr:   false,
+		},
+		{
 			turboServer: "invalid-url",
 			expectErr:   true,
 		},
 	}
 	for _, item := range table {
 		meta := &ServerMeta{
-			item.turboServer,
+			TurboServer: item.turboServer,
+			Version:     item.version,
 		}
 		err := meta.ValidateServerMeta()
 		if item.expectErr {
@@ -39,6 +46,36 @@ func TestValidateServerMeta(t *testing.T) {
 			if err != nil {
 				t.Errorf("Unexpected error: %s", err)
 			}
+		}
+	}
+}
+
+func TestValidateServerMetaVersion(t *testing.T) {
+	table := []struct {
+		version string
+
+		expectedVersion string
+	}{
+		{
+			version:         "",
+			expectedVersion: string(version.PROTOBUF_VERSION),
+		},
+		{
+			version:         "random",
+			expectedVersion: "random",
+		},
+	}
+	for i, item := range table {
+		meta := &ServerMeta{
+			TurboServer: "http://localhost:8080",
+			Version:     item.version,
+		}
+		err := meta.ValidateServerMeta()
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
+		}
+		if meta.Version != item.expectedVersion {
+			t.Errorf("Test case %d failed. Expected %s, got %s", i, item.expectedVersion, meta.Version)
 		}
 	}
 }
@@ -117,8 +154,6 @@ func TestValidateWebSocketConfig(t *testing.T) {
 	}
 }
 
-
-
 func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T) {
 	table := []struct {
 		containerConfig *MediationContainerConfig
@@ -127,7 +162,7 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 		{
 			containerConfig: &MediationContainerConfig{
 				ServerMeta{
-					"invalid",
+					TurboServer: "invalid",
 				},
 				WebSocketConfig{
 					LocalAddress:      "http://127.0.0.1",
@@ -142,7 +177,7 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 		{
 			containerConfig: &MediationContainerConfig{
 				ServerMeta{
-					"http:/127.0.0.1",
+					TurboServer: "http:/127.0.0.1",
 				},
 				WebSocketConfig{
 					LocalAddress: "invalid",
@@ -153,7 +188,7 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 		{
 			containerConfig: &MediationContainerConfig{
 				ServerMeta: ServerMeta{
-					"http:/127.0.0.1",
+					TurboServer: "http:/127.0.0.1",
 				},
 			},
 			expectErr: false,
@@ -172,4 +207,3 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 		}
 	}
 }
-

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -66,7 +66,8 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 	}
 
 	// Sdk Protocol handler
-	sdkProtocolHandler := CreateSdkClientProtocolHandler(remoteMediationClient.allProbes)
+	sdkProtocolHandler := CreateSdkClientProtocolHandler(remoteMediationClient.allProbes,
+		remoteMediationClient.containerConfig.Version)
 	// ------ Websocket transport
 
 	transport := CreateClientWebSocketTransport(connConfig) //, transportClosedNotificationCh)

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -9,12 +9,14 @@ import (
 
 type SdkClientProtocol struct {
 	allProbes map[string]*ProbeProperties
+	version   string
 	//TransportReady chan bool
 }
 
-func CreateSdkClientProtocolHandler(allProbes map[string]*ProbeProperties) *SdkClientProtocol {
+func CreateSdkClientProtocolHandler(allProbes map[string]*ProbeProperties, version string) *SdkClientProtocol {
 	return &SdkClientProtocol{
 		allProbes: allProbes,
+		version:   version,
 		//TransportReady: done,
 	}
 }
@@ -45,7 +47,7 @@ func (clientProtocol *SdkClientProtocol) handleClientProtocol(transport ITranspo
 // ============================== Protocol Version Negotiation =========================
 
 func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) bool {
-	versionStr := string(proto.PROTOBUF_VERSION)
+	versionStr := clientProtocol.version
 	request := &version.NegotiationRequest{
 		ProtocolVersion: &versionStr,
 	}

--- a/pkg/version/proto_version_const.go
+++ b/pkg/version/proto_version_const.go
@@ -1,8 +1,8 @@
-package proto
+package version
 
 // Remote Mediation Clients are expected to send the protobuf message version to ensure compatibility with the server.
 // This version string is sent as part of the registration protocol in the Negotiation message. Only if the version is
 // accepted by the server then the client probes are allowed to register with the server
 const (
-	PROTOBUF_VERSION string = "5.9.0-SNAPSHOT"
+	PROTOBUF_VERSION string = "5.9.0"
 )


### PR DESCRIPTION
add version as one of the parameter in serverMeta. So when in use, the JSON configuration should look like the following:
```json
{
  "communicationConfig": {
    "serverMeta": {
      "version": "5.9.0-SNAPSHOT",
      "turboServer": "<server-url>"
    },
    "restAPIConfig": {
      "opsManagerUserName": "foo",
      "opsManagerPassword": "bar"
    }
  },
  "targetConfig": {
    "probeCategory":"CloudNative",
    "targetType":"some_type",
    "address":"http://127.0.0.1:8080",
    "username":"foo_user",
    "password":"bar_password"
  }
}
```

If user don't provide anything there, it will use the default value, which should be the release value hard coded in version package.