### PR TITLE
Resolved Issue When Version Number is Incorrect

### DIFF
--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -39,7 +39,7 @@ func (tapService *TAPService) ConnectToTurbo() {
 	// Block till a message arrives on the channel
 	status := <-IsRegistered
 	if !status {
-		glog.Infof("Probe " + tapService.ProbeCategory + "::" + tapService.ProbeType + " is not registered")
+		glog.Fatalf("Probe " + tapService.ProbeCategory + "::" + tapService.ProbeType + " is not registered")
 		return
 	}
 	glog.V(3).Infof("Probe " + tapService.ProbeCategory + "::" + tapService.ProbeType + " Registered : === Add Targets ===")


### PR DESCRIPTION
Before the change, if there is incorrect version, go sdk generated the following log then exited the program. 
```
E0728 17:48:53.491103   70680 sdk_client_protocol.go:85] Protocol version negotiation failed%!(EXTRA string=REJECTED) :Protocol version "5.1.0-SNAPSHOT" is not allowed to communicate with server)
E0728 17:48:53.491120   70680 sdk_client_protocol.go:29] Failure during Protocol Negotiation, Registration message will not be sent
E0728 17:48:53.491131   70680 remote_mediation_client.go:135] Registration with server failed
panic: close of nil channel

goroutine 85 [running]:
github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*remoteMediationClient).Stop(0xc4206d6e60)
	/Users/dongyiyang/Sandbox/Go/src/github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go:164 +0x41
github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*remoteMediationClient).Init(0xc4206d6e60, 0xc42031e1c0)
	/Users/dongyiyang/Sandbox/Go/src/github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go:137 +0x6ae
github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.InitMediationContainer(0xc42031e1c0)
	/Users/dongyiyang/Sandbox/Go/src/github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_container.go:77 +0x1a5
created by github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service.(*TAPService).ConnectToTurbo
	/Users/dongyiyang/Sandbox/Go/src/github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service/tap_service.go:36 +0xbe
```
Though we do want it to exit the program but the way it exited was not correct.
Then change is, move the reconnect go routine after the initial registration.