### PR TITLE
set replacement commidity property

### DIFF
--- a/pkg/builder/replacement_entity_meta_data_builder.go
+++ b/pkg/builder/replacement_entity_meta_data_builder.go
@@ -4,6 +4,20 @@ import (
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
+const (
+	PropertyUsed = "used"
+	PropertyCapacity = "capacity"
+	PropertyResizable = "resizable"
+	PropertyLimit = "limit"
+	PropertyPeak = "peak"
+	PropertyComputeUsed = "computeUsed"
+	PropertyReservation = "reservation"
+)
+
+var (
+	defaultPropertyNames = []string{PropertyUsed, PropertyResizable, PropertyComputeUsed, PropertyCapacity}
+)
+
 type ReplacementEntityMetaDataBuilder struct {
 	metaData *proto.EntityDTO_ReplacementEntityMetaData
 }
@@ -46,9 +60,15 @@ func (builder *ReplacementEntityMetaDataBuilder) PatchBuying(commType proto.Comm
 // Set the commodity type whose metric values will be transferred to the entity
 //  builder DTO will be replaced by.
 func (builder *ReplacementEntityMetaDataBuilder) PatchSelling(commType proto.CommodityDTO_CommodityType) *ReplacementEntityMetaDataBuilder {
+	return builder.PatchSellingWithProperty(commType, defaultPropertyNames)
+}
+
+func (builder *ReplacementEntityMetaDataBuilder) PatchSellingWithProperty(commType proto.CommodityDTO_CommodityType, names []string) *ReplacementEntityMetaDataBuilder {
 	builder.metaData.SellingCommTypes = append(builder.metaData.GetSellingCommTypes(),
 		&proto.EntityDTO_ReplacementCommodityPropertyData{
 			CommodityType: &commType,
+			PropertyName: names,
 		})
+
 	return builder
 }

--- a/pkg/builder/replacement_entity_meta_data_builder.go
+++ b/pkg/builder/replacement_entity_meta_data_builder.go
@@ -50,9 +50,14 @@ func (builder *ReplacementEntityMetaDataBuilder) Matching(property string) *Repl
 // Set the commodity type whose metric values will be transferred to the entity
 // builder DTO will be replaced by.
 func (builder *ReplacementEntityMetaDataBuilder) PatchBuying(commType proto.CommodityDTO_CommodityType) *ReplacementEntityMetaDataBuilder {
+	return builder.PatchBuyingWithProperty(commType, defaultPropertyNames)
+}
+
+func (builder *ReplacementEntityMetaDataBuilder) PatchBuyingWithProperty(commType proto.CommodityDTO_CommodityType, names []string) *ReplacementEntityMetaDataBuilder {
 	builder.metaData.BuyingCommTypes = append(builder.metaData.GetBuyingCommTypes(),
 		&proto.EntityDTO_ReplacementCommodityPropertyData{
 			CommodityType: &commType,
+			PropertyName: names,
 		})
 	return builder
 }

--- a/pkg/builder/replacement_entity_meta_data_builder_test.go
+++ b/pkg/builder/replacement_entity_meta_data_builder_test.go
@@ -78,6 +78,7 @@ func TestReplacementEntityMetaDataBuilder_PatchBuying(t *testing.T) {
 			BuyingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{
 				{
 					CommodityType: &commType,
+					PropertyName: defaultPropertyNames,
 				},
 			},
 			SellingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{},
@@ -126,7 +127,7 @@ func TestReplacementEntityMetaDataBuilder_PatchSellingWithProperty(t *testing.T)
 		},
 	}
 
-	propertyNames := []string{PropertyCapacity}
+	propertyNames := []string{PropertyCapacity, PropertyUsed}
 	commType := rand.RandomCommodityType()
 	expectedBuilder := &ReplacementEntityMetaDataBuilder{
 		&proto.EntityDTO_ReplacementEntityMetaData{
@@ -147,3 +148,30 @@ func TestReplacementEntityMetaDataBuilder_PatchSellingWithProperty(t *testing.T)
 	}
 }
 
+func TestReplacementEntityMetaDataBuilder_PatchBuyingWithProperty(t *testing.T) {
+	base := &ReplacementEntityMetaDataBuilder{
+		&proto.EntityDTO_ReplacementEntityMetaData{
+			IdentifyingProp:  []string{},
+			BuyingCommTypes:  []*proto.EntityDTO_ReplacementCommodityPropertyData{},
+			SellingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{},
+		},
+	}
+	propertyNames := []string{PropertyUsed, PropertyCapacity}
+	commType := rand.RandomCommodityType()
+	expectedBuilder := &ReplacementEntityMetaDataBuilder{
+		&proto.EntityDTO_ReplacementEntityMetaData{
+			IdentifyingProp: []string{},
+			BuyingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{
+				{
+					CommodityType: &commType,
+					PropertyName: propertyNames,
+				},
+			},
+			SellingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{},
+		},
+	}
+	builder := base.PatchBuyingWithProperty(commType, propertyNames)
+	if !reflect.DeepEqual(builder, expectedBuilder) {
+		t.Errorf("Expected %+v, got %+v", expectedBuilder, builder)
+	}
+}

--- a/pkg/builder/replacement_entity_meta_data_builder_test.go
+++ b/pkg/builder/replacement_entity_meta_data_builder_test.go
@@ -105,6 +105,7 @@ func TestReplacementEntityMetaDataBuilder_PatchSelling(t *testing.T) {
 			SellingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{
 				{
 					CommodityType: &commType,
+					PropertyName: defaultPropertyNames,
 				},
 			},
 		},
@@ -114,3 +115,35 @@ func TestReplacementEntityMetaDataBuilder_PatchSelling(t *testing.T) {
 		t.Errorf("Expected %+v, got %+v", expectedBuilder, builder)
 	}
 }
+
+
+func TestReplacementEntityMetaDataBuilder_PatchSellingWithProperty(t *testing.T) {
+	base := &ReplacementEntityMetaDataBuilder{
+		&proto.EntityDTO_ReplacementEntityMetaData{
+			IdentifyingProp:  []string{},
+			BuyingCommTypes:  []*proto.EntityDTO_ReplacementCommodityPropertyData{},
+			SellingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{},
+		},
+	}
+
+	propertyNames := []string{PropertyCapacity}
+	commType := rand.RandomCommodityType()
+	expectedBuilder := &ReplacementEntityMetaDataBuilder{
+		&proto.EntityDTO_ReplacementEntityMetaData{
+			IdentifyingProp: []string{},
+			BuyingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{},
+			SellingCommTypes: []*proto.EntityDTO_ReplacementCommodityPropertyData{
+				{
+					CommodityType: &commType,
+					PropertyName: propertyNames,
+				},
+			},
+		},
+	}
+
+	builder := base.PatchSellingWithProperty(commType, propertyNames)
+	if !reflect.DeepEqual(builder, expectedBuilder) {
+		t.Errorf("Expected %+v, got %+v", expectedBuilder, builder)
+	}
+}
+


### PR DESCRIPTION
fix issue [Capacity gets unset while patching the commodity during stitching](https://vmturbo.atlassian.net/browse/OM-24073)

The property names is copied from `com.vmturbo.platform.sdk.common/com.vmturbo.platform.common.builders`.

