### PR TITLE
Change server version string to 6.0.0

### DIFF
--- a/pkg/mediationcontainer/client_protobuf_endpoint.go
+++ b/pkg/mediationcontainer/client_protobuf_endpoint.go
@@ -79,7 +79,7 @@ func (endpoint *ClientProtobufEndpoint) Send(messageToSend *EndpointMessage) {
 	// Marshal protobuf message to raw bytes
 	msgMarshalled, err := goproto.Marshal(messageToSend.ProtobufMessage) // marshal to byte array
 	if err != nil {
-		glog.Errorf("[ClientProtobufEndpoint] during send - marshaling error: ", err)
+		glog.Errorf("[ClientProtobufEndpoint] during send - marshaling error: %s", err)
 		return
 	}
 	// Send using the underlying transport
@@ -88,7 +88,7 @@ func (endpoint *ClientProtobufEndpoint) Send(messageToSend *EndpointMessage) {
 	}
 	err = endpoint.transport.Send(tmsg)
 	if err != nil {
-		glog.Errorf("[ClientProtobufEndpoint] during send - transport error: ", err)
+		glog.Errorf("[ClientProtobufEndpoint] during send - transport error: %s", err)
 		return
 	}
 }

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -408,7 +408,7 @@ func (actionReqHandler *ActionMessageHandler) HandleMessage(serverRequest proto.
 	request := serverRequest.GetActionRequest()
 	probeType := request.ProbeType
 	if actionReqHandler.probes[*probeType] == nil {
-		glog.Errorf("Received: Action request for unknown probe type : ", *probeType)
+		glog.Errorf("Received: Action request for unknown probe type : %s", *probeType)
 		return
 	}
 

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -81,7 +81,7 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 	negotiationResponse.GetNegotiationResult()
 
 	if negotiationResponse.GetNegotiationResult().String() != version.NegotiationAnswer_ACCEPTED.String() {
-		glog.Errorf("Protocol version negotiation failed",
+		glog.Errorf("Protocol version negotiation failed %s",
 			negotiationResponse.GetNegotiationResult().String()+") :"+negotiationResponse.GetDescription())
 		return false
 	}

--- a/pkg/probe/probe_builder_test.go
+++ b/pkg/probe/probe_builder_test.go
@@ -63,7 +63,7 @@ func TestNewProbeBuilderWithRegistrationAndDiscoveryClient(t *testing.T) {
 
 	dc := probe.getDiscoveryClient(targetId)
 	if !reflect.DeepEqual(discoveryClient, dc) {
-		t.Errorf("\nExpected %+v, \ngot      %+v", dc)
+		t.Errorf("\nExpected %+v, \ngot      %+v", discoveryClient, dc)
 	}
 }
 

--- a/pkg/probe/turbo_probe.go
+++ b/pkg/probe/turbo_probe.go
@@ -79,7 +79,7 @@ func (theProbe *TurboProbe) GetTurboDiscoveryClient(accountValues []*proto.Accou
 	target := theProbe.getDiscoveryClient(address)
 
 	if target == nil {
-		glog.Errorf("[GetTurboDiscoveryClient] Cannot find Target for address: " + address)
+		glog.Errorf("[GetTurboDiscoveryClient] Cannot find Target for address: %s", address)
 		//TODO: CreateDiscoveryClient(address, accountValues, )
 		return nil
 	}

--- a/pkg/version/proto_version_const.go
+++ b/pkg/version/proto_version_const.go
@@ -1,8 +1,9 @@
 package version
 
-// Remote Mediation Clients are expected to send the protobuf message version to ensure compatibility with the server.
-// This version string is sent as part of the registration protocol in the Negotiation message. Only if the version is
-// accepted by the server then the client probes are allowed to register with the server
+// Remote Mediation Clients are expected to send the protobuf message version to ensure
+// compatibility with the server.
+// This version string is sent as part of the registration protocol in the Negotiation message.
+// Client probes are allowed to register with the server only if the server accepts the version.
 const (
-	PROTOBUF_VERSION string = "5.9.0"
+	PROTOBUF_VERSION string = "6.0.0"
 )


### PR DESCRIPTION
Turbo GO SDK is to be updated to be compatible and work with Turbonomic Operations Manager v6.0
Updated the version string that will be sent by the TAP services in the Negotiation message during the registration protocol.