### PR TITLE
Drop unsupported discovery intervals from probe registration data

### DIFF
--- a/pkg/builder/registration_builder_test.go
+++ b/pkg/builder/registration_builder_test.go
@@ -85,6 +85,7 @@ func TestProbeInfoBuilder(t *testing.T) {
 		{"Type1", "Category1", 200, 10, 10},
 		{"Type2", "Category2", 200, 10, 10},
 		{"Type3", "Category3", -1, -1, -1},
+		{probeType: "Type4", probeCategory: "Category4"},
 	}
 
 	for _, item := range table {

--- a/pkg/probe/probe_builder.go
+++ b/pkg/probe/probe_builder.go
@@ -2,7 +2,6 @@ package probe
 
 import (
 	"errors"
-	"fmt"
 	"github.com/golang/glog"
 )
 
@@ -52,11 +51,10 @@ func ErrorCreatingProbe(probeType string, probeCategory string) error {
 
 // Get an instance of ProbeBuilder
 func NewProbeBuilder(probeType string, probeCategory string) *ProbeBuilder {
+	probeBuilder := &ProbeBuilder{}
+
 	// Validate probe type and category
 	probeConf, err := NewProbeConfig(probeType, probeCategory)
-
-	probeBuilder := &ProbeBuilder{}
-	probeBuilder.builderError = err
 	if err != nil {
 		probeBuilder.builderError = err
 		return probeBuilder
@@ -83,7 +81,8 @@ func (pb *ProbeBuilder) Create() (*TurboProbe, error) {
 
 	turboProbe, err := newTurboProbe(pb.probeConf)
 	if err != nil {
-		pb.builderError = ErrorCreatingProbe(pb.probeConf.ProbeType, pb.probeConf.ProbeCategory)
+		pb.builderError = ErrorCreatingProbe(pb.probeConf.ProbeType,
+			pb.probeConf.ProbeCategory)
 		glog.Errorf(pb.builderError.Error())
 		return nil, pb.builderError
 	}
@@ -120,7 +119,6 @@ func (pb *ProbeBuilder) WithDiscoveryOptions(options ...DiscoveryMetadataOption)
 	}
 
 	pb.probeConf.SetDiscoveryMetadata(discoveryMetadata)
-	fmt.Printf("Create probe %++v\n", pb.probeConf.discoveryMetadata)
 	return pb
 }
 

--- a/pkg/probe/probe_builder_test.go
+++ b/pkg/probe/probe_builder_test.go
@@ -15,9 +15,12 @@ func TestNewProbeBuilder(t *testing.T) {
 
 	_, _ = builder.Create()
 
-	assert.EqualValues(t, pkg.DEFAULT_FULL_DISCOVERY_IN_SECS, builder.probeConf.discoveryMetadata.GetFullRediscoveryIntervalSeconds())
-	assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED, builder.probeConf.discoveryMetadata.GetIncrementalRediscoveryIntervalSeconds())
-	assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED, builder.probeConf.discoveryMetadata.GetPerformanceRediscoveryIntervalSeconds())
+	assert.EqualValues(t, pkg.DEFAULT_FULL_DISCOVERY_IN_SECS,
+		builder.probeConf.discoveryMetadata.GetFullRediscoveryIntervalSeconds())
+	assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED,
+		builder.probeConf.discoveryMetadata.GetIncrementalRediscoveryIntervalSeconds())
+	assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED,
+		builder.probeConf.discoveryMetadata.GetPerformanceRediscoveryIntervalSeconds())
 }
 
 func TestNewProbeBuilderWithDiscoveryMetadata(t *testing.T) {
@@ -41,8 +44,9 @@ func TestNewProbeBuilderWithDiscoveryMetadata(t *testing.T) {
 	}
 	for _, item := range table {
 		builder := NewProbeBuilder(probeType, probeCat)
-		builder.WithDiscoveryOptions(SetIncrementalRediscoveryIntervalSeconds(item.incremental),
-			SetFullRediscoveryIntervalSeconds(item.full), SetPerformanceRediscoveryIntervalSeconds(item.performance))
+		builder.WithDiscoveryOptions(IncrementalRediscoveryIntervalSecondsOption(item.incremental),
+			FullRediscoveryIntervalSecondsOption(item.full),
+			PerformanceRediscoveryIntervalSecondsOption(item.performance))
 
 		_, _ = builder.Create()
 
@@ -102,11 +106,15 @@ func TestNewProbeBuilderWithRegistrationAndDiscoveryClient(t *testing.T) {
 		t.Errorf("\nExpected %+v, \ngot      %+v", nil, err)
 	}
 
-	if !reflect.DeepEqual(registrationClient.GetSupplyChainDefinition(), probe.RegistrationClient.GetSupplyChainDefinition()) {
-		t.Errorf("\nExpected %+v, \ngot      %+v", registrationClient, probe.RegistrationClient)
+	if !reflect.DeepEqual(registrationClient.GetSupplyChainDefinition(),
+		probe.RegistrationClient.GetSupplyChainDefinition()) {
+		t.Errorf("\nExpected %+v, \ngot      %+v",
+			registrationClient, probe.RegistrationClient)
 	}
-	if !reflect.DeepEqual(registrationClient.GetAccountDefinition(), probe.RegistrationClient.GetAccountDefinition()) {
-		t.Errorf("\nExpected %+v, \ngot      %+v", registrationClient, probe.RegistrationClient)
+	if !reflect.DeepEqual(registrationClient.GetAccountDefinition(),
+		probe.RegistrationClient.GetAccountDefinition()) {
+		t.Errorf("\nExpected %+v, \ngot      %+v",
+			registrationClient, probe.RegistrationClient)
 	}
 
 	dc := probe.getDiscoveryClient(targetId)

--- a/pkg/probe/probe_builder_test.go
+++ b/pkg/probe/probe_builder_test.go
@@ -1,9 +1,57 @@
 package probe
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/turbo-go-sdk/pkg"
 	"reflect"
 	"testing"
 )
+
+func TestNewProbeBuilder(t *testing.T) {
+	probeType := "Type1"
+	probeCat := "Cloud"
+
+	builder := NewProbeBuilder(probeType, probeCat)
+
+	_, _ = builder.Create()
+
+	assert.EqualValues(t, pkg.DEFAULT_FULL_DISCOVERY_IN_SECS, builder.probeConf.discoveryMetadata.GetFullRediscoveryIntervalSeconds())
+	assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED, builder.probeConf.discoveryMetadata.GetIncrementalRediscoveryIntervalSeconds())
+	assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED, builder.probeConf.discoveryMetadata.GetPerformanceRediscoveryIntervalSeconds())
+}
+
+func TestNewProbeBuilderWithDiscoveryMetadata(t *testing.T) {
+	probeType := "Type1"
+	probeCat := "Cloud"
+
+	table := []struct {
+		full        int32
+		incremental int32
+		performance int32
+	}{
+		{full: 0, incremental: 0, performance: 0},
+		{full: -1, incremental: -1, performance: -1},
+		{full: 60, incremental: 120, performance: 300},
+		{full: 30, incremental: 20, performance: 30},
+		{full: 30},
+		{full: -1},
+		{full: 1200},
+		{incremental: 20, performance: 30},
+		{incremental: 60, performance: 60},
+	}
+	for _, item := range table {
+		builder := NewProbeBuilder(probeType, probeCat)
+		builder.WithDiscoveryOptions(SetIncrementalRediscoveryIntervalSeconds(item.incremental),
+			SetFullRediscoveryIntervalSeconds(item.full), SetPerformanceRediscoveryIntervalSeconds(item.performance))
+
+		_, _ = builder.Create()
+
+		dm := builder.probeConf.discoveryMetadata
+		checkDiscoveryMetadata(t, item.full, dm, pkg.FULL_DISCOVERY)
+		checkDiscoveryMetadata(t, item.incremental, dm, pkg.INCREMENTAL_DISCOVERY)
+		checkDiscoveryMetadata(t, item.performance, dm, pkg.PERFORMANCE_DISCOVERY)
+	}
+}
 
 func TestNewProbeBuilderWithoutRegistrationClient(t *testing.T) {
 	probeType := "Type1"

--- a/pkg/probe/probe_config.go
+++ b/pkg/probe/probe_config.go
@@ -1,0 +1,90 @@
+package probe
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-go-sdk/pkg"
+)
+
+// The configuration for Probe
+// probeCategory - information about probe category, used for categorizing the probe in UI
+// probeType - information about probe type
+// discoveryMetadata - information about the discovery intervals for the probe
+type ProbeConfig struct {
+	ProbeType         string
+	ProbeCategory     string
+	discoveryMetadata *DiscoveryMetadata
+}
+
+// Create new instance of ProbeConfig.
+// Sets default discovery intervals for the full, incremental and performance discoveries.
+// Returns error if the probe type and category fields cannot be validated.
+//
+func NewProbeConfig(probeType string, probeCategory string) (*ProbeConfig, error) {
+	if probeType == "" {
+		return nil, ErrorInvalidProbeType()
+	}
+
+	if probeCategory == "" {
+		return nil, ErrorInvalidProbeCategory()
+	}
+
+	probeConf := &ProbeConfig{
+		ProbeCategory:     probeCategory,
+		ProbeType:         probeType,
+		discoveryMetadata: NewDiscoveryMetadata(),
+	}
+
+	return probeConf, nil
+}
+
+// Validate the probe config instance
+// Returns error if the probe type and category fields cannot be validated.
+// Sets default discovery intervals for the full, incremental and performance discoveries.
+func (probeConfig *ProbeConfig) Validate() error {
+	if probeConfig.ProbeType == "" {
+		return ErrorInvalidProbeType()
+	}
+
+	if probeConfig.ProbeCategory == "" {
+		return ErrorInvalidProbeCategory()
+	}
+
+	if probeConfig.discoveryMetadata == nil {
+		probeConfig.discoveryMetadata = NewDiscoveryMetadata()
+	}
+
+	return nil
+}
+
+// Sets the discovery metadata with intervals for the full, incremental and performance discoveries.
+func (probeConfig *ProbeConfig) SetDiscoveryMetadata(discoveryMetadata *DiscoveryMetadata) {
+	// validate the discovery intervals
+	checkRediscoveryIntervalValidity(discoveryMetadata.fullDiscovery,
+		discoveryMetadata.incrementalDiscovery,
+		discoveryMetadata.performanceDiscovery)
+	probeConfig.discoveryMetadata = discoveryMetadata
+}
+
+func checkRediscoveryIntervalValidity(rediscoveryIntervalSec,
+	incrementalDiscoverySec,
+	performanceDiscoverySec int32) {
+
+	if performanceDiscoverySec >= rediscoveryIntervalSec {
+		glog.Warning(discoveryConfigError("performance", "full"))
+	}
+
+	if incrementalDiscoverySec >= rediscoveryIntervalSec {
+		glog.Warning(discoveryConfigError("incremental", "full"))
+	}
+
+	if incrementalDiscoverySec >= performanceDiscoverySec &&
+		performanceDiscoverySec != pkg.DISCOVERY_NOT_SUPPORTED {
+		glog.Warning(discoveryConfigError("incremental", "performance"))
+	}
+}
+
+func discoveryConfigError(discoveryType1, discoveryType2 string) string {
+	return fmt.Sprintf("%s rediscovery interval is greater than %s rediscovery interval, "+
+		"will be skipped!", discoveryType1, discoveryType2)
+}

--- a/pkg/probe/probe_config_test.go
+++ b/pkg/probe/probe_config_test.go
@@ -1,0 +1,90 @@
+package probe
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/turbo-go-sdk/pkg"
+	"testing"
+)
+
+func TestInvalidProbeConf(t *testing.T) {
+	pc, err := NewProbeConfig("", "")
+	assert.NotNil(t, err)
+	assert.Nil(t, pc)
+
+	pc, err = NewProbeConfig("Type1", "")
+	assert.NotNil(t, err)
+	assert.Nil(t, pc)
+
+	pc, err = NewProbeConfig("", "Category1")
+	assert.NotNil(t, err)
+	assert.Nil(t, pc)
+}
+
+func TestProbeConf(t *testing.T) {
+	pc, err := NewProbeConfig("Type1", "Category1")
+	assert.Nil(t, err)
+	assert.NotNil(t, pc)
+	assert.EqualValues(t, "Type1", pc.ProbeType)
+	assert.EqualValues(t, "Category1", pc.ProbeCategory)
+	assert.NotNil(t, pc.discoveryMetadata)
+}
+
+func TestValidateProbeConfInvalid(t *testing.T) {
+	pc := &ProbeConfig{}
+
+	err := pc.Validate()
+	assert.NotNil(t, err)
+
+	pc = &ProbeConfig{
+		ProbeCategory: "Category1",
+	}
+	err = pc.Validate()
+	assert.NotNil(t, err)
+
+	pc = &ProbeConfig{
+		ProbeType: "Type1",
+	}
+	err = pc.Validate()
+	assert.NotNil(t, err)
+}
+
+func TestValidateProbeConf(t *testing.T) {
+	pc := &ProbeConfig{
+		ProbeCategory: "Category1",
+		ProbeType:     "Type1",
+	}
+	err := pc.Validate()
+	assert.Nil(t, err)
+	assert.EqualValues(t, "Type1", pc.ProbeType)
+	assert.EqualValues(t, "Category1", pc.ProbeCategory)
+	assert.NotNil(t, pc.discoveryMetadata)
+}
+
+func TestSetDiscoveryMetadata(t *testing.T) {
+	pc, _ := NewProbeConfig("Type1", "Category1")
+	assert.NotNil(t, pc.discoveryMetadata)
+
+	dm := pc.discoveryMetadata
+	assert.EqualValues(t, pkg.DEFAULT_FULL_DISCOVERY_IN_SECS, pc.discoveryMetadata.fullDiscovery)
+	assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED, pc.discoveryMetadata.incrementalDiscovery)
+	assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED, pc.discoveryMetadata.performanceDiscovery)
+
+	dm.SetFullRediscoveryIntervalSeconds(900)
+	pc.SetDiscoveryMetadata(dm)
+	assert.EqualValues(t, 900, pc.discoveryMetadata.fullDiscovery)
+
+	dm.SetIncrementalRediscoveryIntervalSeconds(10)
+	dm.SetPerformanceRediscoveryIntervalSeconds(10)
+	pc.SetDiscoveryMetadata(dm)
+
+	assert.EqualValues(t, pkg.DEFAULT_MIN_DISCOVERY_IN_SECS, pc.discoveryMetadata.incrementalDiscovery)
+	assert.EqualValues(t, pkg.DEFAULT_MIN_DISCOVERY_IN_SECS, pc.discoveryMetadata.performanceDiscovery)
+
+	dm.SetFullRediscoveryIntervalSeconds(100)
+	dm.SetPerformanceRediscoveryIntervalSeconds(60)
+	dm.SetPerformanceRediscoveryIntervalSeconds(90)
+	pc.SetDiscoveryMetadata(dm)
+	assert.EqualValues(t, 100, pc.discoveryMetadata.fullDiscovery)
+	assert.EqualValues(t, 60, pc.discoveryMetadata.incrementalDiscovery)
+	assert.EqualValues(t, 90, pc.discoveryMetadata.performanceDiscovery)
+}

--- a/pkg/probe/probe_registration.go
+++ b/pkg/probe/probe_registration.go
@@ -65,31 +65,19 @@ func NewDiscoveryMetadata() *DiscoveryMetadata {
 
 type DiscoveryMetadataOption func(*DiscoveryMetadata)
 
-func CreateDiscoveryMetadata(options ...DiscoveryMetadataOption) *DiscoveryMetadata {
-	dm := &DiscoveryMetadata{
-		fullDiscovery:        pkg.DEFAULT_FULL_DISCOVERY_IN_SECS,
-		incrementalDiscovery: pkg.DISCOVERY_NOT_SUPPORTED,
-		performanceDiscovery: pkg.DISCOVERY_NOT_SUPPORTED,
-	}
-	for _, option := range options {
-		option(dm)
-	}
-	return dm
-}
-
-func SetIncrementalRediscoveryIntervalSeconds(incrementalDiscovery int32) func(dm *DiscoveryMetadata) {
+func IncrementalRediscoveryIntervalSecondsOption(incrementalDiscovery int32) func(dm *DiscoveryMetadata) {
 	return func(dm *DiscoveryMetadata) {
 		dm.SetIncrementalRediscoveryIntervalSeconds(incrementalDiscovery)
 	}
 }
 
-func SetPerformanceRediscoveryIntervalSeconds(performanceDiscovery int32) func(dm *DiscoveryMetadata) {
+func PerformanceRediscoveryIntervalSecondsOption(performanceDiscovery int32) func(dm *DiscoveryMetadata) {
 	return func(dm *DiscoveryMetadata) {
 		dm.SetPerformanceRediscoveryIntervalSeconds(performanceDiscovery)
 	}
 }
 
-func SetFullRediscoveryIntervalSeconds(fullDiscovery int32) func(dm *DiscoveryMetadata) {
+func FullRediscoveryIntervalSecondsOption(fullDiscovery int32) func(dm *DiscoveryMetadata) {
 	return func(dm *DiscoveryMetadata) {
 		dm.SetFullRediscoveryIntervalSeconds(fullDiscovery)
 	}
@@ -135,7 +123,7 @@ func checkSecondaryDiscoveryInterval(secondaryDiscoverySec int32, discoveryType 
 	}
 
 	if secondaryDiscoverySec < pkg.DEFAULT_MIN_DISCOVERY_IN_SECS {
-		glog.Warning("%s discovery interval value of %d is below minimum value allowed."+
+		glog.Warningf("%s discovery interval value of %d is below minimum value allowed."+
 			" Setting %s discovery interval to minimum allowed value of %d seconds.",
 			discoveryType, secondaryDiscoverySec, pkg.DEFAULT_MIN_DISCOVERY_IN_SECS)
 		return pkg.DEFAULT_MIN_DISCOVERY_IN_SECS
@@ -152,7 +140,7 @@ func checkFullRediscoveryInterval(rediscoveryIntervalSec int32) int32 {
 	}
 
 	if rediscoveryIntervalSec < pkg.DEFAULT_MIN_DISCOVERY_IN_SECS {
-		glog.Warning("Rediscovery interval value of %d is below minimum value allowed."+
+		glog.Warningf("Rediscovery interval value of %d is below minimum value allowed."+
 			" Setting full rediscovery interval to minimum allowed value of %d seconds.",
 			rediscoveryIntervalSec, pkg.DEFAULT_MIN_DISCOVERY_IN_SECS)
 		return pkg.DEFAULT_MIN_DISCOVERY_IN_SECS

--- a/pkg/probe/probe_registration.go
+++ b/pkg/probe/probe_registration.go
@@ -2,13 +2,8 @@ package probe
 
 import (
 	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-go-sdk/pkg"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-)
-
-const (
-	DEFAULT_FULL_DISCOVERY_IN_SECS int32 = 600
-	DEFAULT_MIN_DISCOVERY_IN_SECS  int32 = 60
-	DISCOVERY_NOT_SUPPORTED        int32 = -1
 )
 
 // ISupplyChainProvider provides the entities defined in the supply chain for a probe
@@ -62,49 +57,108 @@ type DiscoveryMetadata struct {
 // Performance discovery is set to -1 implies that the performance discovery is not supported by the probe.
 func NewDiscoveryMetadata() *DiscoveryMetadata {
 	return &DiscoveryMetadata{
-		fullDiscovery:        DEFAULT_FULL_DISCOVERY_IN_SECS,
-		incrementalDiscovery: DISCOVERY_NOT_SUPPORTED,
-		performanceDiscovery: DISCOVERY_NOT_SUPPORTED,
+		fullDiscovery:        pkg.DEFAULT_FULL_DISCOVERY_IN_SECS,
+		incrementalDiscovery: pkg.DISCOVERY_NOT_SUPPORTED,
+		performanceDiscovery: pkg.DISCOVERY_NOT_SUPPORTED,
 	}
 }
 
+type DiscoveryMetadataOption func(*DiscoveryMetadata)
+
+func CreateDiscoveryMetadata(options ...DiscoveryMetadataOption) *DiscoveryMetadata {
+	dm := &DiscoveryMetadata{
+		fullDiscovery:        pkg.DEFAULT_FULL_DISCOVERY_IN_SECS,
+		incrementalDiscovery: pkg.DISCOVERY_NOT_SUPPORTED,
+		performanceDiscovery: pkg.DISCOVERY_NOT_SUPPORTED,
+	}
+	for _, option := range options {
+		option(dm)
+	}
+	return dm
+}
+
+func SetIncrementalRediscoveryIntervalSeconds(incrementalDiscovery int32) func(dm *DiscoveryMetadata) {
+	return func(dm *DiscoveryMetadata) {
+		dm.SetIncrementalRediscoveryIntervalSeconds(incrementalDiscovery)
+	}
+}
+
+func SetPerformanceRediscoveryIntervalSeconds(performanceDiscovery int32) func(dm *DiscoveryMetadata) {
+	return func(dm *DiscoveryMetadata) {
+		dm.SetPerformanceRediscoveryIntervalSeconds(performanceDiscovery)
+	}
+}
+
+func SetFullRediscoveryIntervalSeconds(fullDiscovery int32) func(dm *DiscoveryMetadata) {
+	return func(dm *DiscoveryMetadata) {
+		dm.SetFullRediscoveryIntervalSeconds(fullDiscovery)
+	}
+}
+
+// Return the time interval in seconds for running the full discovery
 func (dMetadata *DiscoveryMetadata) GetFullRediscoveryIntervalSeconds() int32 {
 	return dMetadata.fullDiscovery
 }
 
+// Return the time interval in seconds for running the incremental discovery
 func (dMetadata *DiscoveryMetadata) GetIncrementalRediscoveryIntervalSeconds() int32 {
 	return dMetadata.incrementalDiscovery
 }
 
+// Return the time interval in seconds for running the performance discovery
 func (dMetadata *DiscoveryMetadata) GetPerformanceRediscoveryIntervalSeconds() int32 {
 	return dMetadata.performanceDiscovery
 }
 
-// Set the discovery interval at which the incremental discovery request will be sent to the probe
+// Set the time interval in seconds for running the incremental discovery
 func (dMetadata *DiscoveryMetadata) SetIncrementalRediscoveryIntervalSeconds(incrementalDiscovery int32) {
-	if incrementalDiscovery >= DEFAULT_MIN_DISCOVERY_IN_SECS {
-		dMetadata.incrementalDiscovery = incrementalDiscovery
-	} else {
-		glog.Errorf("Invalid incremental discovery interval %d", incrementalDiscovery)
-	}
+	interval := checkSecondaryDiscoveryInterval(incrementalDiscovery, pkg.INCREMENTAL_DISCOVERY)
+	dMetadata.incrementalDiscovery = interval
 }
 
-// Set the discovery interval at which the performance discovery request will be sent to the probe
+// Set the time interval in seconds for running the performance discovery
 func (dMetadata *DiscoveryMetadata) SetPerformanceRediscoveryIntervalSeconds(performanceDiscovery int32) {
-	if performanceDiscovery >= DEFAULT_MIN_DISCOVERY_IN_SECS {
-		dMetadata.performanceDiscovery = performanceDiscovery
-	} else {
-		glog.Errorf("Invalid performance discovery interval %d", performanceDiscovery)
-	}
+	interval := checkSecondaryDiscoveryInterval(performanceDiscovery, pkg.PERFORMANCE_DISCOVERY)
+	dMetadata.performanceDiscovery = interval
 }
 
-// Set the discovery interval at which the full discovery request will be sent to the probe
+// Set the time interval in seconds for running the full discovery
 func (dMetadata *DiscoveryMetadata) SetFullRediscoveryIntervalSeconds(fullDiscovery int32) {
-	if fullDiscovery >= DEFAULT_MIN_DISCOVERY_IN_SECS {
-		dMetadata.fullDiscovery = fullDiscovery
-	} else {
-		glog.Errorf("Invalid  discovery interval %d", fullDiscovery)
+	interval := checkFullRediscoveryInterval(fullDiscovery)
+	dMetadata.fullDiscovery = interval
+}
+
+func checkSecondaryDiscoveryInterval(secondaryDiscoverySec int32, discoveryType pkg.DiscoveryType) int32 {
+	if secondaryDiscoverySec <= 0 {
+		glog.V(3).Infof("%s discovery is not supported.", discoveryType)
+		return pkg.DISCOVERY_NOT_SUPPORTED
 	}
+
+	if secondaryDiscoverySec < pkg.DEFAULT_MIN_DISCOVERY_IN_SECS {
+		glog.Warning("%s discovery interval value of %d is below minimum value allowed."+
+			" Setting %s discovery interval to minimum allowed value of %d seconds.",
+			discoveryType, secondaryDiscoverySec, pkg.DEFAULT_MIN_DISCOVERY_IN_SECS)
+		return pkg.DEFAULT_MIN_DISCOVERY_IN_SECS
+	}
+
+	return secondaryDiscoverySec
+}
+
+func checkFullRediscoveryInterval(rediscoveryIntervalSec int32) int32 {
+	if rediscoveryIntervalSec <= 0 {
+		glog.V(3).Infof("No rediscovery interval specified. Using a default value of %d seconds",
+			pkg.DEFAULT_FULL_DISCOVERY_IN_SECS)
+		return pkg.DEFAULT_FULL_DISCOVERY_IN_SECS
+	}
+
+	if rediscoveryIntervalSec < pkg.DEFAULT_MIN_DISCOVERY_IN_SECS {
+		glog.Warning("Rediscovery interval value of %d is below minimum value allowed."+
+			" Setting full rediscovery interval to minimum allowed value of %d seconds.",
+			rediscoveryIntervalSec, pkg.DEFAULT_MIN_DISCOVERY_IN_SECS)
+		return pkg.DEFAULT_MIN_DISCOVERY_IN_SECS
+	}
+
+	return rediscoveryIntervalSec
 }
 
 // IActionPolicyProvider provides the policies for action types supported for

--- a/pkg/probe/probe_registration_test.go
+++ b/pkg/probe/probe_registration_test.go
@@ -13,29 +13,6 @@ func TestNewDiscoveryMetadata(t *testing.T) {
 	assert.EqualValues(t, -1, dm.GetPerformanceRediscoveryIntervalSeconds())
 }
 
-func TestCreateDiscoveryMetadata(t *testing.T) {
-	dm := CreateDiscoveryMetadata()
-	assert.EqualValues(t, 600, dm.GetFullRediscoveryIntervalSeconds())
-	assert.EqualValues(t, -1, dm.GetIncrementalRediscoveryIntervalSeconds())
-	assert.EqualValues(t, -1, dm.GetPerformanceRediscoveryIntervalSeconds())
-
-	dm = CreateDiscoveryMetadata(SetFullRediscoveryIntervalSeconds(1200))
-	assert.EqualValues(t, 1200, dm.GetFullRediscoveryIntervalSeconds())
-	assert.EqualValues(t, -1, dm.GetIncrementalRediscoveryIntervalSeconds())
-	assert.EqualValues(t, -1, dm.GetPerformanceRediscoveryIntervalSeconds())
-
-	dm = CreateDiscoveryMetadata(SetPerformanceRediscoveryIntervalSeconds(600),
-		SetIncrementalRediscoveryIntervalSeconds(900))
-	assert.EqualValues(t, 600, dm.GetFullRediscoveryIntervalSeconds())
-	assert.EqualValues(t, 900, dm.GetIncrementalRediscoveryIntervalSeconds())
-	assert.EqualValues(t, 600, dm.GetPerformanceRediscoveryIntervalSeconds())
-
-	dm = CreateDiscoveryMetadata(SetPerformanceRediscoveryIntervalSeconds(900))
-	assert.EqualValues(t, 600, dm.GetFullRediscoveryIntervalSeconds())
-	assert.EqualValues(t, -1, dm.GetIncrementalRediscoveryIntervalSeconds())
-	assert.EqualValues(t, 900, dm.GetPerformanceRediscoveryIntervalSeconds())
-}
-
 func TestSetDicoveryIntervals(t *testing.T) {
 	table := []struct {
 		full        int32

--- a/pkg/probe/turbo_probe_test.go
+++ b/pkg/probe/turbo_probe_test.go
@@ -1,0 +1,67 @@
+package probe
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/turbo-go-sdk/pkg"
+	"testing"
+)
+
+func TestGetProbeInfoWithDefaultDiscoveryIntervals(t *testing.T) {
+	pc, _ := NewProbeConfig("Type1", "Category1")
+	theProbe, _ := newTurboProbe(pc)
+
+	probeInfo, _ := theProbe.GetProbeInfo()
+	assert.EqualValues(t, pkg.DEFAULT_FULL_DISCOVERY_IN_SECS, probeInfo.GetFullRediscoveryIntervalSeconds())
+	assert.EqualValues(t, 0, probeInfo.GetIncrementalRediscoveryIntervalSeconds())
+	assert.EqualValues(t, 0, probeInfo.GetPerformanceRediscoveryIntervalSeconds())
+}
+
+func TestGetProbeInfoWithIllegalDiscoveryIntervals(t *testing.T) {
+	discoveryMetadata := NewDiscoveryMetadata()
+	discoveryMetadata.SetFullRediscoveryIntervalSeconds(10)
+	discoveryMetadata.SetIncrementalRediscoveryIntervalSeconds(300)
+	discoveryMetadata.SetPerformanceRediscoveryIntervalSeconds(-1)
+	pc, _ := NewProbeConfig("Type1", "Category1")
+	pc.SetDiscoveryMetadata(discoveryMetadata)
+	theProbe, _ := newTurboProbe(pc)
+
+	probeInfo, _ := theProbe.GetProbeInfo()
+	assert.EqualValues(t, pkg.DEFAULT_MIN_DISCOVERY_IN_SECS, probeInfo.GetFullRediscoveryIntervalSeconds())
+	assert.EqualValues(t, 300.0, probeInfo.GetIncrementalRediscoveryIntervalSeconds())
+	assert.EqualValues(t, 0, probeInfo.GetPerformanceRediscoveryIntervalSeconds())
+}
+
+func TestNewProbe(t *testing.T) {
+	pcTable := []struct {
+		probeType string
+		category  string
+	}{
+		{"type1", "category1"},
+		{"", "category1"},
+		{"type1", ""},
+		{"", ""},
+	}
+
+	for _, item := range pcTable {
+		pc := &ProbeConfig{
+			ProbeCategory: item.category,
+			ProbeType:     item.probeType,
+		}
+		theProbe, err := newTurboProbe(pc)
+
+		if pc.Validate() == nil {
+			assert.Nil(t, err)
+			assert.NotNil(t, theProbe)
+			assert.NotNil(t, theProbe.DiscoveryClientMap)
+			assert.NotNil(t, theProbe.ProbeConfiguration)
+			assert.NotNil(t, theProbe.RegistrationClient)
+			discoveryMetadata := theProbe.ProbeConfiguration.discoveryMetadata
+			assert.EqualValues(t, pkg.DEFAULT_FULL_DISCOVERY_IN_SECS, discoveryMetadata.GetFullRediscoveryIntervalSeconds())
+			assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED, discoveryMetadata.GetIncrementalRediscoveryIntervalSeconds())
+			assert.EqualValues(t, pkg.DISCOVERY_NOT_SUPPORTED, discoveryMetadata.GetPerformanceRediscoveryIntervalSeconds())
+		} else {
+			assert.NotNil(t, err)
+			assert.Nil(t, theProbe)
+		}
+	}
+}

--- a/pkg/sdk_constants.go
+++ b/pkg/sdk_constants.go
@@ -1,0 +1,13 @@
+package pkg
+
+type DiscoveryType string
+
+const (
+	DEFAULT_FULL_DISCOVERY_IN_SECS int32 = 600
+	DEFAULT_MIN_DISCOVERY_IN_SECS  int32 = 60
+	DISCOVERY_NOT_SUPPORTED        int32 = -1
+
+	FULL_DISCOVERY        DiscoveryType = "Full"
+	INCREMENTAL_DISCOVERY DiscoveryType = "Incremental"
+	PERFORMANCE_DISCOVERY DiscoveryType = "Performance"
+)


### PR DESCRIPTION
- Restructured how the discovery metadata structure is set in the probe, making it easy to change the default intervals by the probe.
- Probe is always built with a  default discovery metadata structure.
- Added unit tests.