### PR TITLE
Fix OM-27956

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ build:
 	go build ./...
 
 test:
-	@go test -v -race ./pkg/...  
+	@go test -v -race ./pkg/...
 
-.PHONY: fmtcheck 
+.PHONY: fmtcheck
 fmtcheck:
 	@gofmt -l $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
 

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	waitResponseTimeOut = time.Second * 20
+	waitResponseTimeOut = time.Second * 30
 )
 
 type SdkClientProtocol struct {
@@ -67,7 +67,7 @@ func timeOutRead(name string, du time.Duration, ch chan *ParsedMessage) (*Parsed
 		}
 		return msg, nil
 	case <-timer.C:
-		err := fmt.Errorf("[%s]: wait for message from channel timeout.", name)
+		err := fmt.Errorf("[%s]: wait for message from channel timeout(%v seconds).", name, du.Seconds())
 		glog.Error(err.Error())
 		return nil, err
 	}

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -4,7 +4,13 @@ import (
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"github.com/turbonomic/turbo-go-sdk/pkg/version"
 
+	"fmt"
 	"github.com/golang/glog"
+	"time"
+)
+
+const (
+	waitResponseTimeOut = time.Second * 20
 )
 
 type SdkClientProtocol struct {
@@ -45,6 +51,27 @@ func (clientProtocol *SdkClientProtocol) handleClientProtocol(transport ITranspo
 }
 
 // ============================== Protocol Version Negotiation =========================
+func timeOutRead(name string, du time.Duration, ch chan *ParsedMessage) (*ParsedMessage, error) {
+	timer := time.NewTimer(du)
+	select {
+	case msg, ok := <-ch:
+		if !ok {
+			err := fmt.Errorf("[%s]: Endpoint Receiver channel is closed.", name)
+			glog.Error(err.Error())
+			return nil, err
+		}
+		if msg == nil {
+			err := fmt.Errorf("[%s]: Endpoint receive null message.", name)
+			glog.Error(err.Error())
+			return nil, err
+		}
+		return msg, nil
+	case <-timer.C:
+		err := fmt.Errorf("[%s]: wait for message from channel timeout.", name)
+		glog.Error(err.Error())
+		return nil, err
+	}
+}
 
 func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) bool {
 	versionStr := clientProtocol.version
@@ -56,17 +83,17 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 	// Create Protobuf Endpoint to send and handle negotiation messages
 	protoMsg := &NegotiationResponse{} // handler for the response
 	endpoint := CreateClientProtoBufEndpoint("NegotiationEndpoint", transport, protoMsg, true)
+	defer endpoint.CloseEndpoint()
 
 	endMsg := &EndpointMessage{
 		ProtobufMessage: request,
 	}
 	endpoint.Send(endMsg)
-	//defer close(endpoint.MessageReceiver())
+
 	// Wait for the response to be received by the transport and then parsed and put on the endpoint's message channel
-	serverMsg, ok := <-endpoint.MessageReceiver()
-	if !ok {
-		glog.Errorf("[%s] : Endpoint Receiver channel is closed", endpoint.GetName())
-		endpoint.CloseEndpoint()
+	serverMsg, err := timeOutRead(endpoint.GetName(), waitResponseTimeOut, endpoint.MessageReceiver())
+	if err != nil {
+		glog.Errorf("[%s] : read VersionNegotiation response from channel failed: %v", endpoint.GetName(), err)
 		return false
 	}
 	glog.V(3).Infof("[%s] : Received: %++v\n", endpoint.GetName(), serverMsg)
@@ -75,7 +102,6 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 	negotiationResponse := protoMsg.NegotiationMsg
 	if negotiationResponse == nil {
 		glog.Error("Probe Protocol failed, null negotiation response")
-		endpoint.CloseEndpoint()
 		return false
 	}
 	negotiationResponse.GetNegotiationResult()
@@ -86,7 +112,6 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 		return false
 	}
 	glog.V(4).Infof("[SdkClientProtocol] Protocol version is accepted by server: %s", negotiationResponse.GetDescription())
-	endpoint.CloseEndpoint()
 	return true
 }
 
@@ -104,20 +129,20 @@ func (clientProtocol *SdkClientProtocol) HandleRegistration(transport ITransport
 	// Create Protobuf Endpoint to send and handle registration messages
 	protoMsg := &RegistrationResponse{}
 	endpoint := CreateClientProtoBufEndpoint("RegistrationEndpoint", transport, protoMsg, true)
+	defer endpoint.CloseEndpoint()
 
 	endMsg := &EndpointMessage{
 		ProtobufMessage: containerInfo,
 	}
 	endpoint.Send(endMsg)
-	//defer close(endpoint.MessageReceiver())
+
 	// Wait for the response to be received by the transport and then parsed and put on the endpoint's message channel
-	serverMsg, ok := <-endpoint.MessageReceiver()
-	if !ok {
-		glog.Errorf("[HandleRegistration] [%s] : Endpoint Receiver channel is closed", endpoint.GetName())
-		endpoint.CloseEndpoint()
+	serverMsg, err := timeOutRead(endpoint.GetName(), waitResponseTimeOut, endpoint.MessageReceiver())
+	if err != nil {
+		glog.Errorf("[%s] : read Registration response from channel failed: %v", endpoint.GetName(), err)
 		return false
 	}
-	glog.V(2).Infof("[HandleRegistration] [%s] : Received: %++v\n", endpoint.GetName(), serverMsg)
+	glog.V(3).Infof("[%s] : Received: %++v\n", endpoint.GetName(), serverMsg)
 
 	// Handler response
 	registrationResponse := protoMsg.RegistrationMsg
@@ -125,7 +150,6 @@ func (clientProtocol *SdkClientProtocol) HandleRegistration(transport ITransport
 		glog.Errorf("Probe registration failed, null ack")
 		return false
 	}
-	endpoint.CloseEndpoint()
 
 	return true
 }

--- a/pkg/mediationcontainer/sdk_client_protocol_test.go
+++ b/pkg/mediationcontainer/sdk_client_protocol_test.go
@@ -1,0 +1,38 @@
+package mediationcontainer
+
+import (
+	"testing"
+	"time"
+	"fmt"
+)
+
+func TestTimeoutRead(t *testing.T) {
+	du := time.Second*3
+	ch := make(chan *ParsedMessage)
+
+	_, err := timeOutRead("test", du, ch)
+	if err == nil {
+		t.Error("Read should time out with error.")
+	} else {
+		fmt.Println(err.Error())
+	}
+}
+
+func TestTimeoutRead2(t *testing.T) {
+	du := time.Second * 5
+	ch := make(chan *ParsedMessage)
+	msg := &ParsedMessage{}
+
+	go func() {
+		ch <- msg
+	}()
+
+	msg2, err := timeOutRead("test", du, ch)
+	if err != nil {
+		t.Errorf("Read should success without error: %v", err)
+	}
+
+	if msg != msg2 {
+		fmt.Println("received msg is different.")
+	}
+}

--- a/pkg/mediationcontainer/sdk_client_protocol_test.go
+++ b/pkg/mediationcontainer/sdk_client_protocol_test.go
@@ -1,13 +1,13 @@
 package mediationcontainer
 
 import (
+	"fmt"
 	"testing"
 	"time"
-	"fmt"
 )
 
 func TestTimeoutRead(t *testing.T) {
-	du := time.Second*3
+	du := time.Second * 3
 	ch := make(chan *ParsedMessage)
 
 	_, err := timeOutRead("test", du, ch)


### PR DESCRIPTION
[OM-27956](https://vmturbo.atlassian.net/browse/OM-27956)

**Problem**:
   In the initial protocol handshake period, if the websocket is broken before kubeturbo can receive the `VersionNegotiation` response or the `ProbeRegistration` response via the websocket. Then Kubeturbo will be stuck there waiting for this never coming respone.

**Solution**
   Add timeout when waiting for the server response.
