### PR TITLE
Make kubeturbo quit more gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ build:
 	go build ./...
 
 test:
-	@go test -v -race ./pkg/...  
+	@go test -v -race ./pkg/...
 
-.PHONY: fmtcheck 
+.PHONY: fmtcheck
 fmtcheck:
 	@gofmt -l $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
 

--- a/pkg/mediationcontainer/client_protobuf_endpoint.go
+++ b/pkg/mediationcontainer/client_protobuf_endpoint.go
@@ -68,7 +68,6 @@ func (endpoint *ClientProtobufEndpoint) CloseEndpoint() {
 	// Send close to the listener routine
 	if endpoint.stopMsgWaitCh != nil {
 		glog.V(4).Infof("["+endpoint.Name+"] closing stopMsgWaitCh %+v", endpoint.stopMsgWaitCh)
-		endpoint.stopMsgWaitCh <- true
 		close(endpoint.stopMsgWaitCh)
 		glog.V(4).Infof("["+endpoint.Name+"] closed stopMsgWaitCh %+v", endpoint.stopMsgWaitCh)
 	}

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -55,14 +55,14 @@ type ClientWebSocketTransport struct {
 	inputStreamCh            chan []byte // unbuffered channel
 	closeRequested           bool
 	stopListenerCh           chan struct{}
-	mux sync.Mutex
+	mux                      sync.Mutex
 	connClosedNotificationCh chan bool // channel where the transport connection error will be notified
 }
 
 // Instantiate a new ClientWebSocketTransport endpoint for the client
 func CreateClientWebSocketTransport(connConfig *WebSocketConnectionConfig) *ClientWebSocketTransport {
 	transport := &ClientWebSocketTransport{
-		connConfig:               connConfig,
+		connConfig: connConfig,
 	}
 	return transport
 }
@@ -82,7 +82,7 @@ func (clientTransport *ClientWebSocketTransport) Connect() error {
 	glog.V(4).Infof("[Connect] Connected to server " + clientTransport.GetConnectionId())
 
 	clientTransport.stopListenerCh = make(chan struct{}) // Channel to stop the routine that listens for messages
-	clientTransport.inputStreamCh = make(chan []byte)   // Message Queue
+	clientTransport.inputStreamCh = make(chan []byte)    // Message Queue
 	clientTransport.connClosedNotificationCh = make(chan bool)
 	clientTransport.closeRequested = false
 

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -26,7 +26,7 @@ type remoteMediationClient struct {
 	probeResponseChan chan *proto.MediationClientMessage
 	// Channel to stop the mediation client and the underlying transport and message handling
 	stopMediationClientCh  chan struct{}
-	stoppedMediationClient bool // a flag indicating whether the stopMediationClientCh is stopper or not
+	stoppedMediationClient bool // a flag indicating whether the stopMediationClientCh is stopped or not
 }
 
 func CreateRemoteMediationClient(allProbes map[string]*ProbeProperties,
@@ -69,6 +69,7 @@ func (rclient *remoteMediationClient) Init(probeRegisteredMsg chan bool) {
 
 		if !flag {
 			glog.Errorf("Protocol hand shake failed, exiting ...")
+			// MediationContainer will call rclient.Stop() later
 			//rclient.Stop()
 			return
 		}

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -20,23 +20,25 @@ type remoteMediationClient struct {
 	Transport ITransport
 	// Map of Message Handlers to receive server messages
 	MessageHandlers  map[RequestType]RequestHandler
-	stopMsgHandlerCh chan bool
+	stopMsgHandlerCh chan struct{}
 	// Channel for receiving responses from the registered probes to be sent to the server
 	probeResponseChan chan *proto.MediationClientMessage
 	// Channel to stop the mediation client and the underlying transport and message handling
 	stopMediationClientCh chan struct{}
 	//  Channel to stop the routine that monitors the underlying transport connection
-	closeWatcherCh chan bool
+	//closeWatcherCh chan bool
+	stopped bool
 }
 
 func CreateRemoteMediationClient(allProbes map[string]*ProbeProperties,
-	containerConfig *MediationContainerConfig) *remoteMediationClient {
+containerConfig *MediationContainerConfig) *remoteMediationClient {
 	remoteMediationClient := &remoteMediationClient{
 		MessageHandlers:       make(map[RequestType]RequestHandler),
 		allProbes:             allProbes,
 		containerConfig:       containerConfig,
 		probeResponseChan:     make(chan *proto.MediationClientMessage),
 		stopMediationClientCh: make(chan struct{}),
+		stopMsgHandlerCh: make(chan struct{}),
 	}
 
 	glog.V(4).Infof("Created channels : probeResponseChan %s, stopMediationClientCh %s\n",
@@ -50,157 +52,118 @@ func CreateRemoteMediationClient(allProbes map[string]*ProbeProperties,
 	return remoteMediationClient
 }
 
-// Establish connection with the Turbo server -  Blocks till WebSocket connection is open
-// Complete the probe registration protocol with the server and then wait for server messages
-func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh chan bool) {
-	// TODO: Assert that the probes are registered before starting the handshake ??
-
-	//// --------- Create WebSocket Transport
-	connConfig, err := CreateWebSocketConnectionConfig(remoteMediationClient.containerConfig)
+func (rclient *remoteMediationClient) Start(probeRegisteredMsg chan bool) {
+	connConfig, err := CreateWebSocketConnectionConfig(rclient.containerConfig)
 	if err != nil {
-		glog.Errorf("Initialization of remote mediation client failed, null transport : " + err.Error())
-		// TODO: handle error
-		//remoteMediationClient.Stop()
-		//probeRegisteredMsg <- false
+		glog.Errorf("Failed to start RemoteMediationClient: failed to create websocket config: %v", err)
+		probeRegisteredMsg <- false
 		return
 	}
+	rclient.Transport = CreateClientWebSocketTransport(connConfig)
 
-	// Sdk Protocol handler
-	sdkProtocolHandler := CreateSdkClientProtocolHandler(remoteMediationClient.allProbes,
-		remoteMediationClient.containerConfig.Version)
-	// ------ Websocket transport
+	for {
+		flag := rclient.protocolHandShake(connConfig)
+		probeRegisteredMsg <- flag
+		if !flag {
+			glog.Errorf("Protocol hand shake failed, exiting ...")
+			rclient.Stop()
+			return
+		}
 
-	transport := CreateClientWebSocketTransport(connConfig) //, transportClosedNotificationCh)
-	remoteMediationClient.closeWatcherCh = make(chan bool, 1)
-
-	err = transport.Connect() // TODO: blocks till websocket connection is open or until transport is closed
-
-	// handle WebSocket creation errors
-	if err != nil { //transport.ws == nil {
-		glog.Errorf("Initialization of remote mediation client failed, null transport")
-		remoteMediationClient.Stop()
-		probeRegisteredMsgCh <- false
-		return
+		rclient.stopped = false
+		rclient.HandleServerRequests()
+		if rclient.stopped {
+			glog.V(2).Infof("RemoteMediationClient is stopped, exiting ...")
+			return
+		}
 	}
+}
 
-	remoteMediationClient.Transport = transport
+func (rclient *remoteMediationClient) HandleServerRequests() {
+	go rclient.RunServerMessageHandler(rclient.Transport)
 
-	// -------- Start protocol handler separate thread
-	// Initiate protocol to connect to server
-	glog.V(2).Infof("Start sdk client protocol ........")
-	sdkProtocolDoneCh := make(chan bool, 1) // TODO: using a channel so we can add timeout or
-	// wait till message is received from the Protocol handler
-	go sdkProtocolHandler.handleClientProtocol(remoteMediationClient.Transport, sdkProtocolDoneCh)
-
-	status := <-sdkProtocolDoneCh
-
-	glog.V(4).Infof("Sdk client protocol complete, status = ", status)
-	if !status {
-		glog.Errorf("Registration with server failed")
-		probeRegisteredMsgCh <- status
-		remoteMediationClient.Stop()
-		return
-	}
-
-	// Routine to monitor the websocket connection
-	go func() {
-		glog.V(3).Infof("[Reconnect] start monitoring the transport connection")
-		for {
-			select {
-			case <-remoteMediationClient.closeWatcherCh:
-				glog.V(4).Infof("[Reconnect] Exit routine *************")
-				return
-			case <-transport.NotifyClosed():
-				glog.V(2).Infof("[Reconnect] transport endpoint is closed, starting reconnect ...")
-
-				// stop server messages listener
-				remoteMediationClient.stopMessageHandler()
-				// Reconnect
-				err := transport.Connect()
-				// handle WebSocket creation errors
-				if err != nil { //transport.ws == nil {
-					glog.Errorf("[Reconnect] Initialization of remote mediation client failed, null transport")
-					remoteMediationClient.Stop()
-					break
-				}
-				// sdk registration protocol
-				transportReady := make(chan bool, 1)
-				sdkProtocolHandler.handleClientProtocol(transport, transportReady)
-				endProtocol := <-transportReady
-				if !endProtocol {
-					glog.Errorf("[Reconnect] Registration with server failed")
-					remoteMediationClient.Stop()
-					break
-				}
-				// start listener for server messages
-				remoteMediationClient.stopMsgHandlerCh = make(chan bool)
-				go remoteMediationClient.RunServerMessageHandler(remoteMediationClient.Transport)
-				glog.V(3).Infof("[Reconnect] transport endpoint connect complete")
-			} //end select
-		} // end for
-	}() // end go routine
-
-	// --------- Listen for server messages
-	remoteMediationClient.stopMsgHandlerCh = make(chan bool)
-	go remoteMediationClient.RunServerMessageHandler(remoteMediationClient.Transport)
-
-	// Send registration status to the upper layer
-	defer close(probeRegisteredMsgCh)
-	defer close(sdkProtocolDoneCh)
-	probeRegisteredMsgCh <- status
-	glog.V(3).Infof("Sent registration status on channel %s\n", probeRegisteredMsgCh)
-
-	glog.V(3).Infof("Remote mediation initialization complete")
-	// --------- Wait for exit notification
 	select {
-	case <-remoteMediationClient.stopMediationClientCh:
-		glog.V(4).Infof("[Init] Exit routine *************")
+	case <-rclient.stopMediationClientCh:
+		glog.V(1).Info("RemoteMediationClient is stopped. quitting ...")
+		return
+
+	case <-rclient.Transport.NotifyClosed():
+		glog.V(1).Info("RemoteMediationClient transport is closed, starting reconnection ...")
+		//rclient.stopMessageHandler()
 		return
 	}
 }
 
+// protocolHandShake will return only when connection has been built, or proposed protocol version is not accepted.
+func (rclient *remoteMediationClient) protocolHandShake(connConfig *WebSocketConnectionConfig) bool {
+	du := time.Second * 30
+	for {
+		//1. build websocket connection
+		transport := rclient.Transport
+		if err := transport.Connect(); err != nil {
+			glog.Errorf("Initialization of remote mediation client failed, not able to build websocket connection: %v", err)
+			glog.Errorf("Will re-try in %v seconds.", du)
+			time.Sleep(du)
+			continue
+		}
+
+		//2. negotiate version
+		protocolHandler := CreateSdkClientProtocolHandler(rclient.allProbes, rclient.containerConfig.Version)
+		flag, err := protocolHandler.handleClientProtocolX(rclient.Transport)
+		if err == nil {
+			if !flag {
+				return false
+			}
+			return true
+		}
+
+		//3. err != nil
+		glog.Errorf("Protocol handshake error: %v", err)
+		glog.Errorf("Will retry protocol handshake in %v seconds.", du)
+		transport.CloseTransportPoint()
+		time.Sleep(du)
+	}
+}
+
 // Stop the remote mediation client by closing the underlying transport and message handler routines
-func (remoteMediationClient *remoteMediationClient) Stop() {
-	// First stop the transport connection monitor
-	close(remoteMediationClient.closeWatcherCh)
+func (rclient *remoteMediationClient) Stop() {
+	rclient.stopped = true
 	// Stop the server message listener
-	remoteMediationClient.stopMessageHandler()
+	rclient.stopMessageHandler()
 	// Close the transport
-	if remoteMediationClient.Transport != nil {
-		remoteMediationClient.Transport.CloseTransportPoint()
+	if rclient.Transport != nil {
+		rclient.Transport.CloseTransportPoint()
 	}
 	// Notify the client to stop
-	close(remoteMediationClient.stopMediationClientCh)
+	close(rclient.stopMediationClientCh)
 }
 
 // ======================== Listen for server messages ===================
 // Sends message to the server message listener to close the protobuf endpoint and message listener
 func (remoteMediationClient *remoteMediationClient) stopMessageHandler() {
-	if remoteMediationClient.stopMsgHandlerCh != nil {
-		close(remoteMediationClient.stopMsgHandlerCh)
-	}
+	close(remoteMediationClient.stopMsgHandlerCh)
 }
 
 // Checks for incoming server messages received by the ProtoBuf endpoint created to handle server requests
-func (remoteMediationClient *remoteMediationClient) RunServerMessageHandler(transport ITransport) {
+func (rclient *remoteMediationClient) RunServerMessageHandler(transport ITransport) {
 	glog.V(2).Infof("[handleServerMessages] %s : ENTER  ", time.Now())
 
 	// Create Protobuf Endpoint to handle server messages
 	protoMsg := &MediationRequest{} // parser for the server requests
 	endpoint := CreateClientProtoBufEndpoint("ServerRequestEndpoint", transport, protoMsg, false)
+	defer endpoint.CloseEndpoint()
 	logPrefix := "[handleServerMessages][" + endpoint.GetName() + "] : "
 
 	// Spawn a new go routine that serves as a Callback for Probes when their response is ready
-	go remoteMediationClient.runProbeCallback(endpoint) // this also exits using the stopMsgHandlerCh
+	go rclient.runProbeCallback(endpoint) // this also exits using the stopMsgHandlerCh
 
 	// main loop for listening to server message.
 	for {
 		glog.V(2).Infof(logPrefix + "waiting for parsed server message .....") // make debug
 		// Wait for the server request to be received and parsed by the protobuf endpoint
 		select {
-		case <-remoteMediationClient.stopMsgHandlerCh:
+		case <-rclient.stopMsgHandlerCh:
 			glog.V(4).Infof(logPrefix + "Exit routine ***************")
-			endpoint.CloseEndpoint() //to stop the message listener and close the channel
 			return
 		case parsedMsg, ok := <-endpoint.MessageReceiver(): // block till a message appears on the endpoint's message channel
 			if !ok {
@@ -213,18 +176,18 @@ func (remoteMediationClient *remoteMediationClient) RunServerMessageHandler(tran
 			serverRequest := parsedMsg.ServerMsg
 			requestType := getRequestType(serverRequest)
 
-			requestHandler := remoteMediationClient.MessageHandlers[requestType]
+			requestHandler := rclient.MessageHandlers[requestType]
 			if requestHandler == nil {
 				glog.Errorf(logPrefix + "cannot find message handler for request type " + string(requestType))
 			} else {
 				// Dispatch on a new thread
 				// TODO: create MessageOperationRunner to handle this request for a specific message id
-				go requestHandler.HandleMessage(serverRequest, remoteMediationClient.probeResponseChan)
-				glog.Infof(logPrefix + "message dispatched, waiting for next one")
+				go requestHandler.HandleMessage(serverRequest, rclient.probeResponseChan)
+				glog.V(2).Infof(logPrefix + "message dispatched, waiting for next one")
 			}
 		} //end select
 	} //end for
-	glog.Infof(logPrefix + "DONE")
+
 }
 
 // Run probe callback to the probe response to the server.

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -31,14 +31,14 @@ type remoteMediationClient struct {
 }
 
 func CreateRemoteMediationClient(allProbes map[string]*ProbeProperties,
-containerConfig *MediationContainerConfig) *remoteMediationClient {
+	containerConfig *MediationContainerConfig) *remoteMediationClient {
 	remoteMediationClient := &remoteMediationClient{
 		MessageHandlers:       make(map[RequestType]RequestHandler),
 		allProbes:             allProbes,
 		containerConfig:       containerConfig,
 		probeResponseChan:     make(chan *proto.MediationClientMessage),
 		stopMediationClientCh: make(chan struct{}),
-		stopMsgHandlerCh: make(chan struct{}),
+		stopMsgHandlerCh:      make(chan struct{}),
 	}
 
 	glog.V(4).Infof("Created channels : probeResponseChan %s, stopMediationClientCh %s\n",
@@ -52,7 +52,7 @@ containerConfig *MediationContainerConfig) *remoteMediationClient {
 	return remoteMediationClient
 }
 
-func (rclient *remoteMediationClient) Start(probeRegisteredMsg chan bool) {
+func (rclient *remoteMediationClient) Init(probeRegisteredMsg chan bool) {
 	connConfig, err := CreateWebSocketConnectionConfig(rclient.containerConfig)
 	if err != nil {
 		glog.Errorf("Failed to start RemoteMediationClient: failed to create websocket config: %v", err)

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -26,10 +26,8 @@ type remoteMediationClient struct {
 	probeResponseChan chan *proto.MediationClientMessage
 	// Channel to stop the mediation client and the underlying transport and message handling
 	stopMediationClientCh chan struct{}
-	//  Channel to stop the routine that monitors the underlying transport connection
-	//closeWatcherCh chan bool
-	stopped bool
-	mux     sync.Mutex
+	stopped               bool
+	mux                   sync.Mutex
 }
 
 func CreateRemoteMediationClient(allProbes map[string]*ProbeProperties,
@@ -115,7 +113,7 @@ func (rclient *remoteMediationClient) protocolHandShake() bool {
 
 		//2. negotiate version
 		protocolHandler := CreateSdkClientProtocolHandler(rclient.allProbes, rclient.containerConfig.Version)
-		flag, err := protocolHandler.handleClientProtocolX(rclient.Transport)
+		flag, err := protocolHandler.handleClientProtocol(rclient.Transport)
 		if err == nil {
 			if !flag {
 				return false
@@ -224,7 +222,7 @@ func (remoteMediationClient *remoteMediationClient) runProbeCallback(endpoint Pr
 			glog.V(2).Infof("[probeCallback] Exit routine *************")
 			return
 		case msg := <-remoteMediationClient.probeResponseChan:
-			glog.V(3).Infof("[probeCallback] received response on probe channel %v\n ", remoteMediationClient.probeResponseChan)
+			glog.V(3).Info("[probeCallback] received response on probe channel.")
 			endMsg := &EndpointMessage{
 				ProtobufMessage: msg,
 			}

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -12,14 +12,15 @@ import (
 // Abstraction to establish session using the specified protocol with the server
 // and handle server messages for the different probes in the Mediation Container
 type remoteMediationClient struct {
+	// All the probes
 	allProbes map[string]*ProbeProperties
 	// The container info containing the communication config for all the registered probes
 	containerConfig *MediationContainerConfig
 	// Associated Transport
 	Transport ITransport
 	// Map of Message Handlers to receive server messages
-	MessageHandlers    map[RequestType]RequestHandler
-	stopMsgHandlerCh   chan struct{}
+	MessageHandlers  map[RequestType]RequestHandler
+	stopMsgHandlerCh chan struct{}
 
 	// Channel for receiving responses from the registered probes to be sent to the server
 	probeResponseChan chan *proto.MediationClientMessage

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -4,8 +4,8 @@ import (
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"github.com/turbonomic/turbo-go-sdk/pkg/version"
 
-	"github.com/golang/glog"
 	"fmt"
+	"github.com/golang/glog"
 )
 
 type SdkClientProtocol struct {
@@ -22,7 +22,7 @@ func CreateSdkClientProtocolHandler(allProbes map[string]*ProbeProperties, versi
 	}
 }
 
-func (clientProtocol *SdkClientProtocol) handleClientProtocolX(transport ITransport) (bool, error){
+func (clientProtocol *SdkClientProtocol) handleClientProtocolX(transport ITransport) (bool, error) {
 	glog.V(2).Infof("Starting Protocol Negotiation ....")
 
 	//1. negotiation protocol version
@@ -93,7 +93,6 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersionX(transport ITransport)
 	glog.V(3).Infof("[SdkClientProtocol] Protocol version is accepted by server: %s", negotiationResponse.GetDescription())
 	return true, nil
 }
-
 
 // ======================= Registration ============================
 // Send registration message

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -56,7 +56,7 @@ func (clientProtocol *SdkClientProtocol) handleClientProtocol(transport ITranspo
 // ============================== Protocol Version Negotiation =========================
 // Negotiate protocol version: should retry if error != nil;
 func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) (bool, error) {
-	//1. send request  
+	//1. send request
 	versionStr := clientProtocol.version
 	request := &version.NegotiationRequest{
 		ProtocolVersion: &versionStr,
@@ -72,12 +72,12 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 		ProtobufMessage: request,
 	}
 	endpoint.Send(endMsg)
-  
-  //2. wait to get response
+
+	//2. wait to get response
 	// Wait for the response to be received by the transport and then parsed and put on the endpoint's message channel
 	serverMsg, err := timeOutRead(endpoint.GetName(), waitResponseTimeOut, endpoint.MessageReceiver())
-	if !ok {
-		glog.Errorf("[%s] : Endpoint Receiver channel is closed", endpoint.GetName())
+	if err != nil {
+		glog.Errorf("[%s] : read VersionNegotiation response from channel failed: %v", endpoint.GetName(), err)
 		return true, fmt.Errorf("Failed to receive negotiation response.")
 	}
 	glog.V(3).Infof("[%s] : Received negotiation response: %++v\n", endpoint.GetName(), serverMsg)
@@ -86,7 +86,7 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 	negotiationResponse := protoMsg.NegotiationMsg
 	if negotiationResponse == nil {
 		glog.Error("Probe Protocol failed, null negotiation response")
-    return true, fmt.Errorf("negotiation response is null")
+		return true, fmt.Errorf("negotiation response is null")
 	}
 
 	result := negotiationResponse.GetNegotiationResult()
@@ -95,7 +95,7 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 			result.String(), negotiationResponse.GetDescription())
 		return false, nil
 	}
-  glog.V(3).Infof("[SdkClientProtocol] Protocol version is accepted by server: %s", negotiationResponse.GetDescription())
+	glog.V(3).Infof("[SdkClientProtocol] Protocol version is accepted by server: %s", negotiationResponse.GetDescription())
 	return true, nil
 }
 
@@ -158,7 +158,7 @@ func (clientProtocol *SdkClientProtocol) MakeContainerInfo() (*proto.ContainerIn
 		Probes: probes,
 	}, nil
 }
-  
+
 func timeOutRead(name string, du time.Duration, ch chan *ParsedMessage) (*ParsedMessage, error) {
 	timer := time.NewTimer(du)
 	select {
@@ -179,4 +179,4 @@ func timeOutRead(name string, du time.Duration, ch chan *ParsedMessage) (*Parsed
 		glog.Error(err.Error())
 		return nil, err
 	}
-}  
+}

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -22,11 +22,11 @@ func CreateSdkClientProtocolHandler(allProbes map[string]*ProbeProperties, versi
 	}
 }
 
-func (clientProtocol *SdkClientProtocol) handleClientProtocolX(transport ITransport) (bool, error) {
+func (clientProtocol *SdkClientProtocol) handleClientProtocol(transport ITransport) (bool, error) {
 	glog.V(2).Infof("Starting Protocol Negotiation ....")
 
 	//1. negotiation protocol version
-	flag, err := clientProtocol.NegotiateVersionX(transport)
+	flag, err := clientProtocol.NegotiateVersion(transport)
 	if err != nil {
 		glog.Errorf("Protocol negotiation error: %v", err)
 		return flag, err
@@ -50,7 +50,7 @@ func (clientProtocol *SdkClientProtocol) handleClientProtocolX(transport ITransp
 
 // ============================== Protocol Version Negotiation =========================
 // Negotiate protocol version: should retry if error != nil;
-func (clientProtocol *SdkClientProtocol) NegotiateVersionX(transport ITransport) (bool, error) {
+func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) (bool, error) {
 	//1. send request
 	versionStr := clientProtocol.version
 	request := &version.NegotiationRequest{

--- a/pkg/mediationcontainer/transport_endpoint.go
+++ b/pkg/mediationcontainer/transport_endpoint.go
@@ -13,6 +13,7 @@ type ITransport interface {
 	// Close
 	CloseTransportPoint()
 	NotifyClosed() chan bool // Channel where connection closed notification is sent
+	IsClosed() bool
 }
 
 type TransportMessage struct {

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -43,8 +43,9 @@ func (tapService *TAPService) ConnectToTurbo() {
 	// Block till a message arrives on the channel
 	status := <-IsRegistered
 	if !status {
-		glog.Fatalf("Probe " + tapService.ProbeConfiguration.ProbeCategory +
+		glog.Errorf("Probe " + tapService.ProbeConfiguration.ProbeCategory +
 			"::" + tapService.ProbeConfiguration.ProbeType + " is not registered")
+		mediationcontainer.CloseMediationContainer()
 		return
 	}
 	glog.V(3).Infof("Probe " + tapService.ProbeConfiguration.ProbeCategory +


### PR DESCRIPTION
**Problem**
When kubeturbo is killed by Ctrl+C, terminal will show that `panic: close of nil channel`:
<img width="1440" alt="screen shot 2018-02-13 at 7 01 20 pm" src="https://user-images.githubusercontent.com/27221807/36181061-1250dc52-10f1-11e8-8881-2d0317f0d5f6.png">

**Solution**
Simplify and clarify the logical of `remoteMediationClient`.