### PR TITLE
fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: go
 
 go:
-  - 1.7
+  - 1.9
   - tip
 
 go_import_path: github.com/turbonomic/turbo-go-sdk
 
 before_install:
-  - go get github.com/mattn/goveralls
+  - go get -v github.com/mattn/goveralls
+
+matrix:
+  allow_failures:
+    - go: tip
+
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore="pkg/proto/*"
+  - make fmtcheck 
+  - if [ "$TRAVIS_GO_VERSION" == "tip" ] ; then make test ; else $HOME/gopath/bin/goveralls -v -race -service=travis-ci ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ matrix:
 
 script:
   - make fmtcheck 
-  - if [ "$TRAVIS_GO_VERSION" == "tip" ] ; then make test ; else $HOME/gopath/bin/goveralls -v -race -service=travis-ci ; fi
+  - if [ "$TRAVIS_GO_VERSION" == "tip" ] ; then make test ; else $HOME/gopath/bin/goveralls -v -race -service=travis-ci -ignore="pkg/proto/*" ; fi

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ build:
 	go build ./...
 
 test:
-	@go test -v -race ./pkg/...  
+	@go test -v -race ./pkg/...
 
-.PHONY: fmtcheck 
+.PHONY: fmtcheck
 fmtcheck:
 	@gofmt -l $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
 


### PR DESCRIPTION
**Problems** of `.travis.yml`
1. golang version(1.7) is old;
2. no output during goverall process: travis will terminate this process if it can not see any output for a long time;
3. There are some broken ( and invisible) characters in Makefile;

**Solution**
1. update golang version to 1.9;
2. add '-v' option, and allow 'tip' failure;
3. update Makefile
