### PR TITLE
OM-33820:  add ping and resolve concurrent write websocket

### DIFF
--- a/pkg/mediationcontainer/client_protobuf_endpoint.go
+++ b/pkg/mediationcontainer/client_protobuf_endpoint.go
@@ -112,7 +112,7 @@ func (endpoint *ClientProtobufEndpoint) waitForServerMessage() {
 			case rawBytes, ok := <-endpoint.transport.RawMessageReceiver(): // block till  the message bytes from the transport channel,
 				if !ok {
 					glog.Errorf(logPrefix + "transport message channel is closed")
-					break
+					return
 				}
 				// Parse the input stream using the registered message handler
 				messageHandler := endpoint.GetMessageHandler()

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
-	"net"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/websocket"

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -303,9 +303,16 @@ func (clientTransport *ClientWebSocketTransport) performWebSocketConnection() er
 func setupPingPong(ws *websocket.Conn) {
 	h := func(message string) error {
 		glog.V(3).Infof("Recevied ping msg")
-		ws.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(writeWaitTimeout))
-		return nil
+		err := ws.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(writeWaitTimeout))
+		if err == websocket.ErrCloseSent {
+			return nil
+		}
+		if err != nil {
+			glog.Errorf("Failed to send PongMessage: %v", err)
+		}
+		return err
 	}
+
 	ws.SetPingHandler(h)
 
 	h2 := func(message string) error {

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"sync"
 	"time"
+	"net"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/websocket"
@@ -306,7 +307,10 @@ func setupPingPong(ws *websocket.Conn) {
 		err := ws.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(writeWaitTimeout))
 		if err == websocket.ErrCloseSent {
 			return nil
+		} else if e, ok := err.(net.Error); ok && e.Temporary() {
+			return nil
 		}
+
 		if err != nil {
 			glog.Errorf("Failed to send PongMessage: %v", err)
 		}

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -19,7 +20,8 @@ const (
 	Ready            TransportStatus = "ready"
 	handshakeTimeout                 = 60 * time.Second
 	wsReadLimit                      = 33554432 // 32 MB
-	writeWaitSeconds                 = 120
+	writeWaitTimeout                 = 120 * time.Second
+	pingPeriod                       = 60 * time.Second
 )
 
 type TransportStatus string
@@ -50,8 +52,8 @@ func CreateWebSocketConnectionConfig(connConfig *MediationContainerConfig) (*Web
 // ============================ ClientWebSocketTransport - Start, Connect, Close ======================================
 // Implementation of the ITransport for WebSocket communication to send and receive serialized protobuf message bytes
 type ClientWebSocketTransport struct {
-	// current status of the transport layer.
-	status                   TransportStatus
+	status                   TransportStatus // current status of the transport layer.
+	wsMux                    sync.Mutex      // mux to protect ws from concurrent writing (ws.WriteMessage())
 	ws                       *websocket.Conn // created during Connect()
 	connConfig               *WebSocketConnectionConfig
 	inputStreamCh            chan []byte // unbuffered channel
@@ -86,7 +88,8 @@ func (clientTransport *ClientWebSocketTransport) Connect() error {
 	clientTransport.stopListenerCh = make(chan bool, 1) // Channel to stop the routine that listens for messages
 	clientTransport.inputStreamCh = make(chan []byte)   // Message Queue
 	// Message handler for received messages
-	clientTransport.ListenForMessages() // spawns a new routine
+	go clientTransport.ListenForMessages() // spawns a new routine
+	go clientTransport.startPing()
 	return nil
 }
 
@@ -111,20 +114,53 @@ func (clientTransport *ClientWebSocketTransport) CloseTransportPoint() {
 }
 
 // Close current WebSocket connection and set it to nil.
+// TODO: add concurrent control
 func (clientTransport *ClientWebSocketTransport) closeAndResetWebSocket() {
 	if clientTransport.status == Closed {
 		return
 	}
+
 	// close WebSocket
 	if clientTransport.ws != nil {
-		clientTransport.ws.WriteMessage(websocket.CloseMessage, []byte{})
+		glog.V(1).Infof("Begin to send websocket Close frame.")
+		clientTransport.write(websocket.CloseMessage, []byte{})
 		clientTransport.ws.Close()
 		clientTransport.ws = nil
 	}
 	clientTransport.status = Closed
 }
 
+func (ws *ClientWebSocketTransport) write(mtype int, payload []byte) error {
+	ws.wsMux.Lock()
+	defer ws.wsMux.Unlock()
+	ws.ws.SetWriteDeadline(time.Now().Add(writeWaitTimeout))
+	return ws.ws.WriteMessage(mtype, payload)
+}
+
+// keep sending Ping msg to make sure the websocket connection is alive
+// If don't send Ping msg, *some times* the ws.ReadMessage() won't be able to
+//    know that the connection has gone.
+func (ws *ClientWebSocketTransport) startPing() {
+	ticker := time.NewTicker(pingPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ws.stopListenerCh:
+			return
+		case <-ticker.C:
+			glog.V(3).Infof("begin to send Ping message")
+			if err := ws.write(websocket.PingMessage, []byte{}); err != nil {
+				glog.Errorf("Failed to send PingMessage to server:%v", err)
+				return
+			}
+			glog.V(4).Infof("Sent ping message success")
+		}
+	}
+}
+
 // ================================================= Message Listener =============================================
+//TODO: add concurrent control, and better way to test the channel is closed or not
 func (clientTransport *ClientWebSocketTransport) stopListenForMessages() {
 	if clientTransport.stopListenerCh != nil {
 		glog.V(4).Infof("[StopListenForMessages] closing stopListenerCh %+v", clientTransport.stopListenerCh)
@@ -141,51 +177,51 @@ func (clientTransport *ClientWebSocketTransport) stopListenForMessages() {
 func (clientTransport *ClientWebSocketTransport) ListenForMessages() {
 	glog.V(3).Infof("[ListenForMessages] %s : ENTER  ", time.Now())
 
-	go func() {
-		for {
-			glog.V(4).Info("[ListenForMessages] waiting for messages on websocket transport")
-			glog.V(4).Infof("[ListenForMessages] waiting for messages on websocket transport : %++v", clientTransport)
-			select {
-			case <-clientTransport.stopListenerCh:
-				close(clientTransport.inputStreamCh) // This listener routine is the writer for this channel
-				glog.V(4).Infof("[ListenForMessages] closed inputStreamCh %+v", clientTransport.inputStreamCh)
+	for {
+		glog.V(4).Info("[ListenForMessages] waiting for messages on websocket transport")
+		glog.V(4).Infof("[ListenForMessages] waiting for messages on websocket transport : %++v", clientTransport)
+		select {
+		case <-clientTransport.stopListenerCh:
+			glog.V(1).Info("[ListenForMessages] stop listening for message")
+			// close(clientTransport.inputStreamCh) // This listener routine is the writer for this channel
+			return
+		default:
+			if clientTransport.status != Ready {
+				glog.Errorf("WebSocket transport layer status is %s", clientTransport.status)
+				glog.Errorf("WebSocket is not ready.")
+				continue
+			}
+			glog.V(2).Infof("[ListenForMessages]: connected, waiting for server response ...")
+
+			msgType, data, err := clientTransport.ws.ReadMessage()
+			glog.V(3).Infof("Received websocket message of type %d and size %d", msgType, len(data))
+
+			// Notify errors and break
+			if err != nil {
+				// destroy its websocket connection whenever there is an error
+				if err == io.EOF {
+					glog.Errorf("[ListenForMessages] received EOF on websocket %s", err)
+				}
+
+				glog.Errorf("[ListenForMessages] error during receive %v", err)
+				// close current WebSocket connection.
+				clientTransport.closeAndResetWebSocket()
+				clientTransport.stopListenForMessages()
+
+				//notify upper components this connection error
+				clientTransport.connClosedNotificationCh <- true // Note: this will block till the message is received
+
+				glog.V(1).Infof("[ListenForMessages] websocket error notified, stop lisening for messages.")
 				return
-			default:
-				if clientTransport.status != Ready {
-					glog.Errorf("WebSocket transport layer status is %s", clientTransport.status)
-					glog.Errorf("WebSocket is not ready.")
-					continue
-				}
-				glog.V(2).Infof("[ListenForMessages]: connected, waiting for server response ...")
+			}
+			// write the message on the channel
+			glog.V(3).Infof("[ListenForMessages] received message on websocket of size %d", len(data))
 
-				msgType, data, err := clientTransport.ws.ReadMessage()
-				glog.V(3).Infof("Received websocket message of type %d and size %d", msgType, len(data))
+			clientTransport.queueRawMessage(data) // Note: this will block till the message is read
+			glog.V(4).Infof("[ListenForMessages] delivered websocket message, continue listening for server messages...")
+		} //end select
+	} //end for
 
-				// Notify errors and break
-				if err != nil {
-					//TODO handle err according to possible type. Now reconnect when never there is an error, which may not necessary.
-					if err == io.EOF {
-						glog.Errorf("[ListenForMessages] received EOF on websocket %s", err)
-					}
-
-					glog.Errorf("[ListenForMessages] error during receive %v", err)
-					//notify error with the connection
-					clientTransport.connClosedNotificationCh <- true // Note: this will block till the message is received
-					// close current WebSocket connection.
-					clientTransport.closeAndResetWebSocket()
-					clientTransport.stopListenForMessages()
-
-					glog.V(2).Infof("[ListenForMessages] error notified, will re-establish websocket connection")
-					break
-				}
-				// write the message on the channel
-				glog.V(3).Infof("[ListenForMessages] received message on websocket of size %d", len(data))
-
-				clientTransport.queueRawMessage(data) // Note: this will block till the message is read
-				glog.V(4).Infof("[ListenForMessages] delivered websocket message, continue listening for server messages...")
-			} //end select
-		} //end for
-	}()
 	glog.V(4).Infof("[ListenForMessages] : END")
 }
 
@@ -211,13 +247,13 @@ func (clientTransport *ClientWebSocketTransport) Send(messageToSend *TransportMe
 		glog.Errorf("WebSocket transport layer status is %s", clientTransport.status)
 		return errors.New("Cannot send message: web socket is not ready")
 	}
+
 	if messageToSend == nil { //.RawMsg == nil {
 		glog.Errorf("Cannot send message : marshalled msg is nil")
 		return errors.New("Cannot send message: marshalled msg is nil")
 	}
-	du := time.Second * time.Duration(writeWaitSeconds)
-	clientTransport.ws.SetWriteDeadline(time.Now().Add(du))
-	err := clientTransport.ws.WriteMessage(websocket.BinaryMessage, messageToSend.RawMsg)
+
+	err := clientTransport.write(websocket.BinaryMessage, messageToSend.RawMsg)
 	if err != nil {
 		glog.Errorf("Error sending message on client transport: %s", err)
 		return fmt.Errorf("Error sending message on client transport: %s", err)
@@ -244,8 +280,10 @@ func (clientTransport *ClientWebSocketTransport) performWebSocketConnection() er
 
 			time.Sleep(connRetryIntervalSeconds)
 		} else {
+			setupPingPong(ws)
 			clientTransport.ws = ws
 			clientTransport.status = Ready
+
 			glog.V(2).Infof("[performWebSocketConnection]*********** Connected to server " + clientTransport.GetConnectionId())
 			glog.V(2).Infof("WebSocket transport layer is ready.")
 
@@ -254,6 +292,23 @@ func (clientTransport *ClientWebSocketTransport) performWebSocketConnection() er
 	}
 	glog.V(4).Infof("[performWebSocketConnection] exit connect routine, close = %s ", clientTransport.closeRequested)
 	return errors.New("Abort client socket connect, transport is closed")
+}
+
+// set up websocket Ping-Pong protocol handlers
+func setupPingPong(ws *websocket.Conn) {
+	h := func(message string) error {
+		glog.V(3).Infof("Recevied ping msg")
+		ws.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(writeWaitTimeout))
+		return nil
+	}
+	ws.SetPingHandler(h)
+
+	h2 := func(message string) error {
+		glog.V(3).Infof("Received pong msg")
+		return nil
+	}
+	ws.SetPongHandler(h2)
+	return
 }
 
 func openWebSocketConn(connConfig *WebSocketConnectionConfig, vmtServerUrl string) (*websocket.Conn, error) {

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -145,7 +145,6 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 	go remoteMediationClient.RunServerMessageHandler(remoteMediationClient.Transport)
 
 	// Send registration status to the upper layer
-	defer close(probeRegisteredMsgCh)
 	defer close(sdkProtocolDoneCh)
 	probeRegisteredMsgCh <- status
 	glog.V(3).Infof("Sent registration status on channel %s\n", probeRegisteredMsgCh)

--- a/pkg/probe/turbo_probe.go
+++ b/pkg/probe/turbo_probe.go
@@ -138,7 +138,7 @@ func (theProbe *TurboProbe) DiscoverTarget(accountValues []*proto.AccountValue) 
 		discoveryResponse = theProbe.createDiscoveryTargetErrorDTO("Full", targetId, err)
 		glog.Errorf("Error discovering target %s", discoveryResponse)
 	}
-	glog.V(3).Infof("Discovery response: %s", discoveryResponse)
+	glog.V(4).Infof("Discovery response: %s", discoveryResponse)
 	return discoveryResponse
 }
 

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -34,6 +34,7 @@ func (tapService *TAPService) DisconnectFromTurbo() {
 
 func (tapService *TAPService) ConnectToTurbo() {
 	glog.V(4).Infof("[ConnectToTurbo] Enter ******* ")
+	tapService.disconnectFromTurbo = make(chan struct{})
 	IsRegistered := make(chan bool, 1)
 
 	// start a separate go routine to connect to the Turbo server
@@ -69,10 +70,11 @@ func (tapService *TAPService) ConnectToTurbo() {
 	glog.V(4).Infof("[ConnectToTurbo] End ******")
 
 	// Once connected the mediation container will keep running till a disconnect message is sent to the tap service
-	tapService.disconnectFromTurbo = make(chan struct{})
 	select {
 	case <-tapService.disconnectFromTurbo:
+		glog.V(2).Infof("Begin to stop TAP service.")
 		mediationcontainer.CloseMediationContainer()
+		glog.V(2).Infof("TAP service is stopped.")
 		return
 	}
 }

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"net/url"
+	"time"
 
 	restclient "github.com/turbonomic/turbo-api/pkg/client"
 
@@ -40,8 +41,9 @@ func (tapService *TAPService) addTarget(isRegistered chan bool) {
 	select {
 	case status := <-isRegistered:
 		if !status {
+			glog.Errorf("Probe %v registration failed.", pinfo)
 			close(tapService.disconnectFromTurbo)
-			glog.Fatalf("Probe %v registration failed.", pinfo)
+			glog.Errorf("Notified to close TAP service.")
 			return
 		}
 		break

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -3,7 +3,6 @@ package service
 import (
 	"fmt"
 	"net/url"
-	"time"
 
 	restclient "github.com/turbonomic/turbo-api/pkg/client"
 


### PR DESCRIPTION
[OM-33820](https://vmturbo.atlassian.net/browse/OM-33820)

**Problem**
Kubeturbo cannot communicate with Tomcat server properly after Tomcat server restarts.
Based on my observation, there are two bugs in the websocket module for this problem:

1.  Concurrent write to websocket
   This can cause Kubeturbo exit with panic, and not be able to send the `Close` message to Tomcat server.

2.  **_Some times_** it cannot detect that the websocket has gone.
   So it will not try to reconnect to Tomcat server.

**Solution**
1. fix the concurrent write by a lock.
   Every write will need to acquire the lock first. This may hurt the performance, but in kubeturbo or other probes, there won't be many writes.

   Besides, this is a temporary fix. We can switch to [another solution](https://github.com/songbinliu/turbo_probe/blob/master/pkg/wsocket/wsocket.go) without write lock in the future.

2. fix the detection by adding a `Ping` thread.
  A separate goroutine will send `Ping` message periodically. In my comparison tests, with this thread, 
kubeturbo is able to detect the broken websocket every time.

