### PR TITLE
Add method to set peak value in commodity DTO builder.

### DIFF
--- a/pkg/builder/commodity_dto_builder.go
+++ b/pkg/builder/commodity_dto_builder.go
@@ -99,6 +99,14 @@ func (cb *CommodityDTOBuilder) Used(used float64) *CommodityDTOBuilder {
 	return cb
 }
 
+func (cb *CommodityDTOBuilder) Peak(peak float64) *CommodityDTOBuilder {
+	if cb.err != nil {
+		return cb
+	}
+	cb.peak = &peak
+	return cb
+}
+
 func (cb *CommodityDTOBuilder) Reservation(reservation float64) *CommodityDTOBuilder {
 	if cb.err != nil {
 		return cb


### PR DESCRIPTION
Currently, at server side, only VM VCPU capacity and used values are patched. However, it causes some inconsistent issue for the peak value. To avoid it, Kubeturbo needs also set peak value and patch it at server side.

This is the change at turbo-go-sdk side.