### PR TITLE
Methods in merged entity metadata builder

### DIFF
--- a/pkg/builder/merged_entity_meta_data_builder.go
+++ b/pkg/builder/merged_entity_meta_data_builder.go
@@ -239,18 +239,19 @@ func (builder *MergedEntityMetadataBuilder) Build() (*proto.MergedEntityMetadata
 		metadata.CommoditiesSold = append(metadata.CommoditiesSold, builder.commoditiesSold...)
 	}
 
-	//if len(builder.commBoughtMetadataList) > 0 {
-	//	for _, commBoughtMetadata := range builder.commBoughtMetadataList {
-	//		commBought := &proto.MergedEntityMetadata_CommodityBoughtMetadata {
-	//			CommodityMetadata: commBoughtMetadata.commBoughtList,
-	//			ProviderType:      &commBoughtMetadata.providerType,
-	//		}
-	//		if commBoughtMetadata.replaceProvider {
-	//			commBought.ReplacesProvider = &commBoughtMetadata.providerToReplace
-	//		}
-	//		metadata.CommoditiesBought = append(metadata.CommoditiesBought, commBought)
-	//	}
-	//}
+	if len(builder.commBoughtMetadataList) > 0 {
+		for _, commBoughtMetadata := range builder.commBoughtMetadataList {
+			commBought := &proto.MergedEntityMetadata_CommodityBoughtMetadata{
+				CommodityMetadata: commBoughtMetadata.commBoughtList,
+				ProviderType:      &commBoughtMetadata.providerType,
+			}
+			if commBoughtMetadata.replaceProvider {
+				commBought.ReplacesProvider = &commBoughtMetadata.providerToReplace
+			}
+			metadata.CommoditiesBought = append(metadata.CommoditiesBought, commBought)
+		}
+	}
+
 	return metadata, nil
 }
 


### PR DESCRIPTION
- Edited the builder for setting up the bought commodity metadata in the merged entity builder
- Methods that are exported outside of the sdk package should start with capital letter.