### PR TITLE
allow the probe to continue even if the rest api does not authenticate

### DIFF
--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -156,7 +156,6 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 	_, err = apiClient.Login()
 	if err != nil {
 		glog.Errorf("Cannot login to the Turbo API Client: %v", err)
-		return builder
 	}
 
 	builder.tapService.Client = apiClient


### PR DESCRIPTION
allow the probe to continue even if the rest api does not authenticated assuming the user can manually add the target when using SSO/SAML

Before the change:
```
I0613 17:03:30.857008   69808 kubeturbo.go:106] Run Kubeturbo service (GIT_COMMIT: )
I0613 17:03:30.966083   69808 mediation_container.go:52] ---------- Created MediationContainer ----------
E0613 17:03:31.009958   69808 tap_service.go:158] Cannot login to the Turbo API Client: unsuccessful Turbo server login response: 401 Unauthorized. Invalid credentials.
I0613 17:03:31.010632   69808 mediation_container.go:105] Registered Cloud Native::Kubernetes-2305542295
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1cd7afb]

goroutine 1 [running]:
github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service.(*TAPService).ConnectToTurbo(0xc00000dc80)
	/Users/esara/go/src/github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/service/tap_service.go:74 +0x6b
github.com/turbonomic/kubeturbo/cmd/kubeturbo/app.(*VMTServer).Run(0xc00030c000)
	/Users/esara/go/src/github.com/turbonomic/kubeturbo/cmd/kubeturbo/app/kubeturbo_builder.go:273 +0x60d
main.main()
	/Users/esara/go/src/github.com/turbonomic/kubeturbo/cmd/kubeturbo/kubeturbo.go:108 +0x1cd
```

After the change:
```
I0613 16:49:13.161709   69746 kubeturbo.go:106] Run Kubeturbo service (GIT_COMMIT: )
I0613 16:49:13.309105   69746 mediation_container.go:52] ---------- Created MediationContainer ----------
E0613 16:49:13.441596   69746 tap_service.go:158] Cannot login to the Turbo API Client: unsuccessful Turbo server login response: 401 Unauthorized. Invalid credentials.
I0613 16:49:13.443103   69746 mediation_container.go:105] Registered Cloud Native::Kubernetes-2305542295
I0613 16:49:13.443379   69746 mediation_container.go:67] Initializing mediation container .....
I0613 16:49:13.443424   69746 client_websocket_transport.go:276] [performWebSocketConnection]: wss://10.10.173.164/vmturbo/remoteMediation
E0613 16:49:13.576758   69746 tap_service.go:62] Error while adding Cloud Native Kubernetes-2305542295 target: Null login session cookie
I0613 16:49:13.593340   69746 remote_mediation_client.go:222] [handleServerMessages][ServerRequestEndpoint] : message dispatched, waiting for next one
I0613 16:49:13.803372   69746 remote_mediation_client.go:222] [handleServerMessages][ServerRequestEndpoint] : message dispatched, waiting for next one
I0613 16:49:19.883860   69746 mediation_container.go:81] [CloseMediationContainer] Closing mediation container .....
```