### PR TITLE
SDK change to support building group DTO with cluster constraint

### DIFF
--- a/pkg/builder/group/cluster_builder.go
+++ b/pkg/builder/group/cluster_builder.go
@@ -1,0 +1,37 @@
+package group
+
+import "github.com/turbonomic/turbo-go-sdk/pkg/proto"
+
+type ClusterBuilder struct {
+	*AbstractConstraintGroupBuilder
+}
+
+// Cluster is the builder for a group with Cluster constraint
+func Cluster(id string) *ClusterBuilder {
+	return &ClusterBuilder{
+		&AbstractConstraintGroupBuilder{
+			StaticGroup(id),
+			newConstraintBuilder(proto.GroupDTO_CLUSTER, id),
+		},
+	}
+}
+
+func (c *ClusterBuilder) OfType(eType proto.EntityDTO_EntityType) *ClusterBuilder {
+	c.AbstractBuilder.OfType(eType)
+	return c
+}
+
+func (c *ClusterBuilder) WithEntities(entities []string) *ClusterBuilder {
+	c.AbstractBuilder.WithEntities(entities)
+	return c
+}
+
+func (c *ClusterBuilder) WithDisplayName(displayName string) *ClusterBuilder {
+	c.AbstractBuilder.WithDisplayName(displayName)
+	c.ConstraintInfoBuilder.WithDisplayName(displayName)
+	return c
+}
+
+func (c *ClusterBuilder) Build() (*proto.GroupDTO, error) {
+	return c.AbstractConstraintGroupBuilder.Build()
+}

--- a/pkg/builder/group/cluster_builder_test.go
+++ b/pkg/builder/group/cluster_builder_test.go
@@ -1,0 +1,37 @@
+package group
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"testing"
+)
+
+func TestClusterHasWrongEntityType(t *testing.T) {
+	clusterBuilder := Cluster("cluster1")
+	_, err := clusterBuilder.
+		OfType(proto.EntityDTO_CONTAINER_POD).
+		WithEntities([]string{"vm1", "vm2"}).
+		Build()
+	fmt.Printf("Cluster error %v\n", err)
+	assert.NotNil(t, err)
+}
+
+func TestClusterHasNoMemberList(t *testing.T) {
+	clusterBuilder := Cluster("cluster1")
+	_, err := clusterBuilder.
+		OfType(proto.EntityDTO_VIRTUAL_MACHINE).
+		Build()
+	fmt.Printf("Cluster error %v\n", err)
+	assert.NotNil(t, err)
+}
+
+func TestClusterHasClusterConstraintInfo(t *testing.T) {
+	clusterBuilder := Cluster("cluster1")
+	clusterDTO, err := clusterBuilder.
+		OfType(proto.EntityDTO_VIRTUAL_MACHINE).
+		WithEntities([]string{"vm1", "vm2"}).
+		Build()
+	assert.Nil(t, err)
+	assert.Equal(t, clusterDTO.GetConstraintInfo().GetConstraintType(), proto.GroupDTO_CLUSTER)
+}

--- a/pkg/builder/group/constraint_group_builder.go
+++ b/pkg/builder/group/constraint_group_builder.go
@@ -1,0 +1,121 @@
+package group
+
+import (
+	"fmt"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+)
+
+// ConstraintInfoBuilder is the builder for the constraint info data in a Group DTO
+type ConstraintInfoBuilder struct {
+	constraintType        proto.GroupDTO_ConstraintType
+	constraintId          string
+	constraintName        string
+	constraintDisplayName string
+	providerTypePtr       *proto.EntityDTO_EntityType
+	isBuyer               bool
+
+	maxBuyers int32
+}
+
+func newConstraintBuilder(constraintType proto.GroupDTO_ConstraintType, constraintId string) *ConstraintInfoBuilder {
+
+	return &ConstraintInfoBuilder{
+		constraintName: constraintId,
+		constraintType: constraintType,
+	}
+}
+
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithName(constraintName string) *ConstraintInfoBuilder {
+	constraintInfoBuilder.constraintName = constraintName
+	return constraintInfoBuilder
+}
+
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithDisplayName(constraintDisplayName string) *ConstraintInfoBuilder {
+	constraintInfoBuilder.constraintDisplayName = constraintDisplayName
+	return constraintInfoBuilder
+}
+
+// Set the entity type of the seller group for the buyer entities
+func (constraintInfoBuilder *ConstraintInfoBuilder) WithSellerType(providerType proto.EntityDTO_EntityType) *ConstraintInfoBuilder {
+	constraintInfoBuilder.providerTypePtr = &providerType
+	return constraintInfoBuilder
+}
+
+// Set the maximum number of buyer entities allowed in the policy
+func (constraintInfoBuilder *ConstraintInfoBuilder) AtMostBuyers(maxBuyers int32) *ConstraintInfoBuilder {
+	constraintInfoBuilder.maxBuyers = maxBuyers
+	return constraintInfoBuilder
+}
+
+// Build the ConstraintInfo DTO
+func (constraintInfoBuilder *ConstraintInfoBuilder) Build() (*proto.GroupDTO_ConstraintInfo, error) {
+	constraintInfo := &proto.GroupDTO_ConstraintInfo{
+		ConstraintId:          &constraintInfoBuilder.constraintId,
+		ConstraintType:        &constraintInfoBuilder.constraintType,
+		ConstraintName:        &constraintInfoBuilder.constraintName,
+		ConstraintDisplayName: &constraintInfoBuilder.constraintDisplayName,
+	}
+
+	if constraintInfoBuilder.isBuyer {
+		// buyer group specific metadata
+		constraintInfo.BuyerMetaData = &proto.GroupDTO_BuyerMetaData{}
+		boolVal := true
+		constraintInfo.IsBuyer = &boolVal
+		// seller entity type should be provided for buyer seller policies
+		setProvider := (constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_AFFINITY) ||
+			(constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_ANTI_AFFINITY)
+		if setProvider && constraintInfoBuilder.providerTypePtr == nil {
+			return nil, fmt.Errorf("seller type required")
+		}
+		constraintInfo.BuyerMetaData.SellerType = constraintInfoBuilder.providerTypePtr
+		// max buyers allowed
+		if constraintInfoBuilder.maxBuyers > 0 {
+			constraintInfo.BuyerMetaData.AtMost = &constraintInfoBuilder.maxBuyers
+		}
+	}
+
+	// seller group specific metadata
+	needsComplementary := constraintInfoBuilder.constraintType == proto.GroupDTO_BUYER_SELLER_ANTI_AFFINITY
+	constraintInfo.NeedComplementary = &needsComplementary
+
+	return constraintInfo, nil
+}
+
+// AbstractConstraintGroupBuilder is the builder of a Group with constraint
+type AbstractConstraintGroupBuilder struct {
+	*AbstractBuilder
+	*ConstraintInfoBuilder
+}
+
+// Build policy group with Constraint Info
+func (groupBuilder *AbstractConstraintGroupBuilder) Build() (*proto.GroupDTO, error) {
+
+	groupDTO, err := groupBuilder.AbstractBuilder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build group: %v", err)
+	}
+
+	var constraintInfo *proto.GroupDTO_ConstraintInfo
+	constraintInfo, err = groupBuilder.ConstraintInfoBuilder.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build group constraint: %v", err)
+	}
+
+	if groupBuilder.constraintType == proto.GroupDTO_CLUSTER {
+		entityType := *groupBuilder.entityTypePtr
+		if entityType != proto.EntityDTO_VIRTUAL_MACHINE &&
+			entityType != proto.EntityDTO_PHYSICAL_MACHINE &&
+			entityType != proto.EntityDTO_STORAGE {
+			return nil, fmt.Errorf("failed to build cluster: unsupported entity type %v", entityType)
+		}
+	}
+
+	// set constraint info in the group DTO
+	info := &proto.GroupDTO_ConstraintInfo_{
+		ConstraintInfo: constraintInfo,
+	}
+
+	groupDTO.Info = info
+
+	return groupDTO, nil
+}

--- a/pkg/builder/group/group_builder.go
+++ b/pkg/builder/group/group_builder.go
@@ -91,7 +91,7 @@ func (groupBuilder *AbstractBuilder) Build() (*proto.GroupDTO, error) {
 	groupDTO.IsConsistentResizing = &groupBuilder.consistentResize
 
 	if groupBuilder.ec.Count() > 0 {
-		glog.Errorf("GroupBuilder Error %s : %s\n", groupBuilder.groupId, groupBuilder.ec.Error())
+		glog.Errorf("%s : %s", groupBuilder.groupId, groupBuilder.ec.Error())
 		return nil, fmt.Errorf("%s: %s", groupBuilder.groupId, groupBuilder.ec.Error())
 	}
 
@@ -114,7 +114,7 @@ func (groupBuilder *AbstractBuilder) OfType(eType proto.EntityDTO_EntityType) *A
 
 	// Check entity type
 	if groupBuilder.entityTypePtr != nil && *groupBuilder.entityTypePtr != eType {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot add members, input EntityType - %s is not consistent with existing EntityType %s ",
+		groupBuilder.ec.Collect(fmt.Errorf("cannot add members, input entityType %v is not consistent with existing entityType %v",
 			eType, *groupBuilder.entityTypePtr))
 		return groupBuilder
 	}
@@ -127,14 +127,14 @@ func (groupBuilder *AbstractBuilder) OfType(eType proto.EntityDTO_EntityType) *A
 
 func (groupBuilder *AbstractBuilder) setupEntityType(groupDTO *proto.GroupDTO) error {
 	if groupBuilder.entityTypePtr == nil {
-		return fmt.Errorf("Entity type is not set")
+		return fmt.Errorf("entity type is not set")
 	}
 	// Validate entity type
 	entityType := *groupBuilder.entityTypePtr
 	_, valid := proto.EntityDTO_EntityType_name[int32(entityType)]
 
 	if !valid {
-		return fmt.Errorf("Invalid entity type %v\n", entityType)
+		return fmt.Errorf("invalid entity type %v", entityType)
 	}
 
 	// Setup entity type
@@ -147,7 +147,7 @@ func (groupBuilder *AbstractBuilder) WithEntities(entities []string) *AbstractBu
 
 	// Assert that the group is a static group
 	if groupBuilder.groupType != STATIC_GROUP {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot set member uuid list for dynamic group"))
+		groupBuilder.ec.Collect(fmt.Errorf("cannot set member uuid list for dynamic group"))
 		return groupBuilder
 	}
 	groupBuilder.memberList = entities
@@ -158,7 +158,7 @@ func (groupBuilder *AbstractBuilder) WithEntities(entities []string) *AbstractBu
 func (groupBuilder *AbstractBuilder) setUpStaticMembers(groupDTO *proto.GroupDTO) error {
 
 	if len(groupBuilder.memberList) == 0 {
-		return fmt.Errorf("Empty member list")
+		return fmt.Errorf("empty member list")
 	}
 
 	// Set the Group DTO member field
@@ -176,7 +176,7 @@ func (groupBuilder *AbstractBuilder) MatchingEntities(matching *Matching) *Abstr
 
 	// Assert that the group is a dynamci group
 	if groupBuilder.groupType != DYNAMIC_GROUP {
-		groupBuilder.ec.Collect(fmt.Errorf("Cannot set matching criteria for static group"))
+		groupBuilder.ec.Collect(fmt.Errorf("cannot set matching criteria for static group"))
 		return groupBuilder
 	}
 	groupBuilder.matching = matching
@@ -187,7 +187,7 @@ func (groupBuilder *AbstractBuilder) MatchingEntities(matching *Matching) *Abstr
 func (groupBuilder *AbstractBuilder) setUpDynamicGroup(groupDTO *proto.GroupDTO) error {
 
 	if groupBuilder.matching == nil {
-		return fmt.Errorf("Null matching criteria for member selection")
+		return fmt.Errorf("null matching criteria for member selection")
 	}
 
 	var selectionSpecList []*proto.GroupDTO_SelectionSpec


### PR DESCRIPTION
This pull request add changes to the turbo-go-sdk to support building a group DTO with cluster constraint. As a result of the change, some refactoring is also done:

* Added `cluster_builder.go` to export the `ClusterBuilder`.
* Because `ClusterBuilder` is essentially an `AbstractConstraintGroupBuilder`, so I moved `AbstractConstraintGroupBuilder` out of the `policy_builder.go` file and created a `constraint_group_builder.go` for it, so it is cleaner.
* Corrected some formatting issues.
* Added test cases.