### PR TITLE
Fix kubeturbo cannot log in to Turbo server when sidecar is injected

### DIFF
--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -53,6 +53,14 @@ func (tapService *TAPService) addTarget(isRegistered chan bool) {
 
 	//2. register the targets
 	glog.V(2).Infof("Probe %v is registered. Begin to add targets.", pinfo)
+
+	// Login to obtain the session cookie
+	if _, err := tapService.Client.Login(); err != nil {
+		glog.Errorf("Cannot login to the Turbo API Client: %v", err)
+		return
+	}
+	glog.V(2).Infof("Successfully logged in to Turbo server.")
+
 	targetInfos := tapService.GetProbeTargets()
 	for _, targetInfo := range targetInfos {
 		target := targetInfo.GetTargetInstance()
@@ -150,13 +158,7 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 		builder.err = fmt.Errorf("Error during create Turbo API client: %s\n", err)
 		return builder
 	}
-	glog.V(4).Infof("The Turbo API client is create successfully: %v", apiClient)
-
-	// Login to obtain the session cookie
-	_, err = apiClient.Login()
-	if err != nil {
-		glog.Errorf("Cannot login to the Turbo API Client: %v", err)
-	}
+	glog.V(4).Infof("The Turbo API client is created successfully: %v", apiClient)
 
 	builder.tapService.Client = apiClient
 


### PR DESCRIPTION
Currently when `kubeturbo` is started, it performs the following actions in the following order:

1. Log in to the Turbo server with the configured username and password, and obtain a session cookie
1. Register itself as a probe to the Turbo server, and establish a websocket connection, **retry every 30 seconds if connection fails**
1. Add a target with Turbo server using the session cookie obtained from a successful login

We observe a problem when a `kubeturbo` pod is injected with an `istio-proxy` sidecar, the login would fail. This is because the `kubeturbo` container and the `istio-proxy` container are started at the same time, and before the `istio-proxy` container is fully started, the network is not ready, that is why we are seeing the following error messages in the log:

```
E1119 15:25:59.989735       1 tap_service.go:158] Cannot login to the Turbo API Client: Failed to login  https://t8c-istio-ingressgateway.lemur: Post https://t8c-istio-ingressgateway.lemur/vmturbo/rest/login: dial tcp 10.106.25.5:443: connect: connection refused
I1119 15:25:59.989790       1 turbo_probe.go:77] [NewTurboProbe] Created TurboProbe: &{0xc00013e390 0xc0000d0240 map[] <nil>}
I1119 15:25:59.989830       1 mediation_container.go:105] Registered Cloud Native::Kubernetes-2636037929
I1119 15:25:59.989959       1 kubeturbo_builder.go:273] No leader election
I1119 15:25:59.989981       1 kubeturbo_builder.go:275] ********** Start runnning Kubeturbo Service **********
I1119 15:25:59.991467       1 mediation_container.go:67] Initializing mediation container .....
I1119 15:25:59.991514       1 mediation_container.go:74] Registering 1 probes
I1119 15:25:59.991559       1 client_websocket_transport.go:280] [performWebSocketConnection]: wss://t8c-istio-ingressgateway.lemur/vmturbo/remoteMediation
E1119 15:25:59.995903       1 client_websocket_transport.go:345] Failed to connect to server(wss://t8c-istio-ingressgateway.lemur/vmturbo/remoteMediation): dial tcp 10.106.25.5:443: connect: connection refused
...
...
1119 15:26:30.003396       1 tap_service.go:55] Probe Cloud Native::Kubernetes-2636037929 is registered. Begin to add targets.
I1119 15:26:30.003410       1 remote_mediation_client.go:185] [handleServerMessages] 2019-11-19 15:26:30.0033832 +0000 UTC m=+30.114183701 : ENTER  
I1119 15:26:30.003526       1 remote_mediation_client.go:197] [handleServerMessages][ServerRequestEndpoint] : waiting for parsed server message .....
E1119 15:26:30.003600       1 tap_service.go:62] Error while adding Cloud Native Kubernetes-2636037929 target: Null login session cookie
```
Basically both the initial login and the websocket connection failed because the `istio-proxy` container had not started. After 30 seconds, the websocket connection was successful, but adding target failed due to Null session cookie.

The proposed solution is to move the Login to after the probe is registered. Probe registration already has retry logic implemented. If the probe is successfully registered, we know that the network must be ready.

Tested the solution with an injected `kubeturbo` pod, and observe that the target can be added after 30 seconds (1 retry):
```
I1119 21:26:35.487177       1 kubeturbo_builder.go:275] ********** Start runnning Kubeturbo Service **********
I1119 21:26:35.488818       1 mediation_container.go:67] Initializing mediation container .....
I1119 21:26:35.489061       1 mediation_container.go:74] Registering 1 probes
I1119 21:26:35.489219       1 client_websocket_transport.go:280] [performWebSocketConnection]: wss://t8c-istio-ingressgateway.lemur/vmturbo/remoteMediation
E1119 21:26:35.494852       1 client_websocket_transport.go:345] Failed to connect to server(wss://t8c-istio-ingressgateway.lemur/vmturbo/remoteMediation): dial tcp 10.106.25.5:443: connect: connection refused
I1119 21:27:05.470621       1 client_websocket_transport.go:295] [performWebSocketConnection]*********** Connected to server 10.106.25.5:443::10.1.11.2:57444
I1119 21:27:05.470728       1 client_websocket_transport.go:296] WebSocket transport layer is ready.
...
...
I1119 21:27:05.510837       1 tap_service.go:55] Probe Cloud Native::Kubernetes-2636037929 is registered. Begin to add targets.
...
I1119 21:27:05.765213       1 tap_service.go:62] Successfully logged in to Turbo server.
```
