### PR TITLE
Declutter logging

### DIFF
--- a/pkg/mediationcontainer/client_protobuf_endpoint.go
+++ b/pkg/mediationcontainer/client_protobuf_endpoint.go
@@ -123,7 +123,7 @@ func (endpoint *ClientProtobufEndpoint) waitForServerMessage() {
 					continue
 				}
 
-				glog.V(3).Infof(logPrefix+"received message is: %++v\n", parsedMsg.ServerMsg.GetMediationServerMessage())
+				glog.V(3).Infof(logPrefix+"received message: %+v", parsedMsg.ServerMsg.GetMediationServerMessage())
 
 				// Put the parsed message on the endpoint's channel
 				// - this will block till the upper layer receives this message

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -196,7 +196,7 @@ func (clientTransport *ClientWebSocketTransport) ListenForMessages() {
 				glog.Errorf("WebSocket is not ready.")
 				continue
 			}
-			glog.V(2).Infof("[ListenForMessages]: connected, waiting for server response ...")
+			glog.V(3).Infof("[ListenForMessages]: connected, waiting for server response ...")
 
 			msgType, data, err := clientTransport.ws.ReadMessage()
 			glog.V(3).Infof("Received websocket message of type %d and size %d", msgType, len(data))

--- a/pkg/mediationcontainer/protobuf_endpoint.go
+++ b/pkg/mediationcontainer/protobuf_endpoint.go
@@ -76,7 +76,6 @@ func (nr *NegotiationResponse) GetMessage() goproto.Message {
 }
 
 func (nr *NegotiationResponse) parse(rawMsg []byte) (*ParsedMessage, error) {
-	glog.V(2).Infof("Parsing %s\n", rawMsg)
 	// Parse the input stream
 	serverMsg := &version.NegotiationAnswer{}
 	err := goproto.Unmarshal(rawMsg, serverMsg)
@@ -96,7 +95,6 @@ func (rr *RegistrationResponse) GetMessage() goproto.Message {
 }
 
 func (rr *RegistrationResponse) parse(rawMsg []byte) (*ParsedMessage, error) {
-	glog.V(3).Infof("Parsing %s\n", rawMsg)
 	// Parse the input stream
 	serverMsg := &proto.Ack{}
 	err := goproto.Unmarshal(rawMsg, serverMsg)

--- a/pkg/probe/turbo_probe.go
+++ b/pkg/probe/turbo_probe.go
@@ -303,7 +303,7 @@ func (theProbe *TurboProbe) GetProbeInfo() (*proto.ProbeInfo, error) {
 	}
 
 	probeInfo := probeInfoBuilder.Create()
-	glog.V(2).Infof("ProbeInfo %++v\n", probeInfo)
+	glog.V(3).Infof("ProbeInfo %+v", probeInfo)
 
 	return probeInfo, nil
 }


### PR DESCRIPTION
There are many unmeaningful and confusing logging from `turbo-go-sdk` package, which makes the product look rather unprofessional. For example:

* We would directly print out a byte array, which sometimes produce garbage letters, and sometimes produce nothing:
```
I1017 07:19:02.967487       1 protobuf_endpoint.go:79] Parsing^@^REProtocol version "7.21.0-SNAPSHOT" is allowed to interact with server
...
```
* Unnecessary verbose logging at V(2) level, for example:
```
I1017 07:19:02.967725       1 turbo_probe.go:306] ProbeInfo probeType:"Kubernetes-1848268059" probeCategory:"Cloud Native" supplyChainDefinitionSet:<templateClass:VIRTUAL_APPLICATION templateType:BASE templatePriority:0 commodityBought:<key:<templateClass:APPLICATION providerType:LAYERED_OVER cardinalityMax:2147483647 cardinalityMin:0 > value:<commodityType:APPLICATION key:"fake" > > > supplyChainDefinitionSet:<templateClass:APPLICATION templateType:BASE templatePriority:0 commoditySold:<commodityType:APPLICATION key:"fake" > commodityBought:<key:<templateClass:CONTAINER providerType:HOSTING cardinalityMax:1 cardinalityMin:1 > value:<commodityType:VCPU > value:<commodityType:VMEM > value:<commodityType:APPLICATION key:"fake" > > > supplyChainDefinitionSet:<templateClass:CONTAINER templateType:BASE templatePriority:0 commoditySold:<commodityType:VCPU > commoditySold:<commodityType:VMEM > commoditySold:<commodityType:APPLICATION key:"fake" > commodityBought:<key:<templateClass:CONTAINER_POD providerType:HOSTING cardinalityMax:1 cardinalityMin:1 > value:<commodityType:VCPU > value:<commodityType:VMEM > value:<commodityType:VMPM_ACCESS key:"fake" > > > supplyChainDefinitionSet:<templateClass:CONTAINER_POD templateType:BASE templatePriority:0 commoditySold:<commodityType:VCPU > commoditySold:<commodityType:VMEM > commoditySold:<commodityType:VMPM_ACCESS key:"fake" > commodityBought:<key:<templateClass:VIRTUAL_MACHINE providerType:HOSTING cardinalityMax:1 cardinalityMin:1 > value:<commodityType:VCPU > value:<commodityType:VMEM > value:<commodityType:VCPU_REQUEST > value:<commodityType:VMEM_REQUEST > value:<commodityType:NUMBER_CONSUMERS > > commodityBought:<key:<templateClass:VIRTUAL_DATACENTER providerType:LAYERED_OVER cardinalityMax:2147483647 cardinalityMin:0 > value:<commodityType:CPU_ALLOCATION key:"fake" > value:<commodityType:MEM_ALLOCATION key:"fake" > value:<commodityType:CPU_REQUEST_ALLOCATION key:"fake" > value:<commodityType:MEM_REQUEST_ALLOCATION key:"fake" > > externalLink:<key:VIRTUAL_MACHINE value:<buye
...
...
...
```
* Confusing messages which looks rather serious but in fact it is harmless
```
I1017 07:19:03.052896       1 client_websocket_transport.go:199] [ListenForMessages]: connected, waiting for server response ...
E1017 07:19:03.053111       1 remote_mediation_client.go:217] [handleServerMessages][ServerRequestEndpoint] : cannot find message handler for request type Unknown
```
In this ticket, I mainly fix the logging during kubeturbo startup (i.e., version negotiations, probe registrations, target adding, etc). There are certain log pollution in turbo-api package, which I plan to fix later. 

The following is an example of what it looks like after the fix with V(2) logging:
```
I1121 02:47:04.227105       1 client_websocket_transport.go:295] [performWebSocketConnection]*********** Connected to server 10.106.25.5:443::10.1.11.27:58640
I1121 02:47:04.227143       1 client_websocket_transport.go:296] WebSocket transport layer is ready.
I1121 02:47:04.227193       1 remote_mediation_client.go:90] Start sdk client protocol ........
I1121 02:47:04.227213       1 sdk_client_protocol.go:32] Starting protocol negotiation ....
I1121 02:47:04.237253       1 sdk_client_protocol.go:115] Protocol negotiation result: ACCEPTED. Protocol version "7.21" is allowed to interact with server.
I1121 02:47:04.237288       1 sdk_client_protocol.go:41] Starting probe Registration ....
I1121 02:47:04.237301       1 sdk_client_protocol.go:163] SdkClientProtocol] Creating Probe Info for Kubernetes-2636037929
I1121 02:47:04.252176       1 sdk_client_protocol.go:155] Probe registration succeeded.
I1121 02:47:04.252225       1 tap_service.go:55] Probe Cloud Native::Kubernetes-2636037929 is registered. Begin to add targets.
I1121 02:47:04.359203       1 remote_mediation_client.go:212] [handleServerMessages][ServerRequestEndpoint] : received message with request type SetProperty.
I1121 02:47:04.527331       1 tap_service.go:62] Successfully logged in to Turbo server.
E1121 02:47:04.690220       1 tap_service.go:70] Error while adding Cloud Native Kubernetes-2636037929 target: Target &{Cloud Native   [] [0xc000493790 0xc000493860 0xc000493930]  []  Kubernetes-2636037929 } exists
I1121 02:50:38.813254       1 remote_mediation_client.go:212] [handleServerMessages][ServerRequestEndpoint] : received message with request type Discovery.
...
...
```