### PR TITLE
Allow adding target through either api or topology-processor service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,10 @@ module github.com/turbonomic/turbo-go-sdk
 go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.1
 	github.com/gorilla/websocket v1.2.0
-	github.com/pmezard/go-difflib v1.0.0
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.3.0
-	github.com/turbonomic/turbo-api v0.0.0-20200316022338-fbd613adc0eb
+	github.com/turbonomic/turbo-api v0.0.0-20200409182717-9a979f01a6bb
 )

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/gorilla/websocket v1.2.0
 	github.com/stretchr/testify v1.3.0
-	github.com/turbonomic/turbo-api v0.0.0-20200409182717-9a979f01a6bb
+	github.com/turbonomic/turbo-api v0.0.0-20200413140231-3bef8fb11708
 )

--- a/go.sum
+++ b/go.sum
@@ -11,13 +11,7 @@ github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
-github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70 h1:xfnOa96E4g6MRfLPSVyL4Aprmxf8NBjsUyqUoW0VnIs=
-github.com/turbonomic/turbo-api v0.0.0-20180816193551-ed948ba97e70/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-api v0.0.0-20200316022338-fbd613adc0eb h1:A+jP6oP/UqI3HMnokNO/ZV9wU3Px7qynxyYBchWmZqE=
-github.com/turbonomic/turbo-api v0.0.0-20200316022338-fbd613adc0eb/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-api v0.0.0-20200409182717-9a979f01a6bb h1:d4Kl4ii0HeIGOS66BTaaq98NIJ1XuuhVS/3SepWihw8=
+github.com/turbonomic/turbo-api v0.0.0-20200409182717-9a979f01a6bb/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=

--- a/go.sum
+++ b/go.sum
@@ -13,5 +13,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/turbonomic/turbo-api v0.0.0-20200409182717-9a979f01a6bb h1:d4Kl4ii0HeIGOS66BTaaq98NIJ1XuuhVS/3SepWihw8=
-github.com/turbonomic/turbo-api v0.0.0-20200409182717-9a979f01a6bb/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-api v0.0.0-20200413140231-3bef8fb11708 h1:ez1BHxInhrLoSoXYvuHyZwJTJaS0H/c+2axY8VZIW+c=
+github.com/turbonomic/turbo-api v0.0.0-20200413140231-3bef8fb11708/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=

--- a/pkg/mediationcontainer/client_protobuf_endpoint.go
+++ b/pkg/mediationcontainer/client_protobuf_endpoint.go
@@ -157,7 +157,7 @@ func (endpoint *ClientProtobufEndpoint) waitForSingleServerMessage() {
 			parsedMsg = &ParsedMessage{} //create empty message
 		}
 
-		glog.V(4).Infof("["+endpoint.Name+"][waitForSingleServerMessage] : Received: %s\n", parsedMsg)
+		glog.V(4).Infof("["+endpoint.Name+"][waitForSingleServerMessage] : Received: %+v", parsedMsg)
 
 		// - this will block till the upper layer receives this message
 		msgChannel := endpoint.MessageReceiver()

--- a/pkg/mediationcontainer/mediation_communication_config.go
+++ b/pkg/mediationcontainer/mediation_communication_config.go
@@ -6,14 +6,18 @@ import (
 	"net/url"
 
 	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-api/pkg/client"
 	"github.com/turbonomic/turbo-go-sdk/pkg/version"
 )
 
-const (
-	defaultRemoteMediationServer       string = "/vmturbo/remoteMediation"
-	defaultRemoteMediationServerUser   string = "vmtRemoteMediation"
-	defaultRemoteMediationServerPwd    string = "vmtRemoteMediation"
-	defaultRemoteMediationLocalAddress string = "http://127.0.0.1"
+var (
+	defaultRemoteMediationServerEndpoints = map[string]string{
+		client.API:               "/vmturbo/remoteMediation",
+		client.TopologyProcessor: "/remoteMediation",
+	}
+	defaultRemoteMediationServerUser   = "vmtRemoteMediation"
+	defaultRemoteMediationServerPwd    = "vmtRemoteMediation"
+	defaultRemoteMediationLocalAddress = "http://127.0.0.1"
 )
 
 type ServerMeta struct {
@@ -36,11 +40,11 @@ func (meta *ServerMeta) ValidateServerMeta() error {
 }
 
 type WebSocketConfig struct {
-	LocalAddress      string `json:"localAddress,omitempty"`
-	WebSocketUsername string `json:"websocketUsername,omitempty"`
-	WebSocketPassword string `json:"websocketPassword,omitempty"`
-	ConnectionRetry   int16  `json:"connectionRetry,omitempty"`
-	WebSocketPath     string `json:"websocketPath,omitempty"`
+	LocalAddress       string `json:"localAddress,omitempty"`
+	WebSocketUsername  string `json:"websocketUsername,omitempty"`
+	WebSocketPassword  string `json:"websocketPassword,omitempty"`
+	ConnectionRetry    int16  `json:"connectionRetry,omitempty"`
+	WebSocketEndpoints map[string]string
 }
 
 func (wsc *WebSocketConfig) ValidateWebSocketConfig() error {
@@ -49,12 +53,11 @@ func (wsc *WebSocketConfig) ValidateWebSocketConfig() error {
 	}
 	// Make sure the local address string provided is a valid URL
 	if _, err := url.ParseRequestURI(wsc.LocalAddress); err != nil {
-		return fmt.Errorf("Invalid local address url found in WebSocket config: %v", wsc)
+		return fmt.Errorf("invalid local address url found in WebSocket config: %v", wsc)
 	}
 
-	if wsc.WebSocketPath == "" {
-		wsc.WebSocketPath = defaultRemoteMediationServer
-	}
+	wsc.WebSocketEndpoints = defaultRemoteMediationServerEndpoints
+
 	if wsc.WebSocketUsername == "" {
 		wsc.WebSocketUsername = defaultRemoteMediationServerUser
 	}

--- a/pkg/mediationcontainer/mediation_communication_config_test.go
+++ b/pkg/mediationcontainer/mediation_communication_config_test.go
@@ -115,7 +115,7 @@ func TestValidateWebSocketConfig(t *testing.T) {
 			LocalAddress:      item.localAddress,
 			WebSocketUsername: item.wsUsername,
 			WebSocketPassword: item.wsPassword,
-			WebSocketPath:     item.wsPath,
+			WebSocketPaths:    item.wsPath,
 			ConnectionRetry:   item.connectionRetry,
 		}
 		err := config.ValidateWebSocketConfig()
@@ -131,14 +131,14 @@ func TestValidateWebSocketConfig(t *testing.T) {
 				LocalAddress:      item.localAddress,
 				WebSocketUsername: item.wsUsername,
 				WebSocketPassword: item.wsPassword,
-				WebSocketPath:     item.wsPath,
+				WebSocketPaths:    item.wsPath,
 				ConnectionRetry:   item.connectionRetry,
 			}
 			if expectedConfig.LocalAddress == "" {
 				expectedConfig.LocalAddress = defaultRemoteMediationLocalAddress
 			}
-			if expectedConfig.WebSocketPath == "" {
-				expectedConfig.WebSocketPath = defaultRemoteMediationServer
+			if expectedConfig.WebSocketPaths == "" {
+				expectedConfig.WebSocketPaths = defaultRemoteMediationServerEndpoints
 			}
 			if expectedConfig.WebSocketUsername == "" {
 				expectedConfig.WebSocketUsername = defaultRemoteMediationServerUser
@@ -168,7 +168,7 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 					LocalAddress:      "http://127.0.0.1",
 					WebSocketUsername: rand.String(10),
 					WebSocketPassword: rand.String(10),
-					WebSocketPath:     rand.String(10),
+					WebSocketPaths:    rand.String(10),
 					ConnectionRetry:   10,
 				},
 			},

--- a/pkg/mediationcontainer/mediation_communication_config_test.go
+++ b/pkg/mediationcontainer/mediation_communication_config_test.go
@@ -86,14 +86,10 @@ func TestValidateWebSocketConfig(t *testing.T) {
 		wsUsername      string
 		wsPassword      string
 		connectionRetry int16
-		wsPath          string
-
-		expectedConfig *WebSocketConfig
-
-		expectErr bool
+		expectedConfig  *WebSocketConfig
+		expectErr       bool
 	}{
 		{
-
 			expectErr: false,
 		},
 		{
@@ -105,9 +101,7 @@ func TestValidateWebSocketConfig(t *testing.T) {
 			wsUsername:      rand.String(5),
 			wsPassword:      rand.String(5),
 			connectionRetry: 5,
-			wsPath:          rand.String(5),
-
-			expectErr: false,
+			expectErr:       false,
 		},
 	}
 	for _, item := range table {
@@ -115,7 +109,6 @@ func TestValidateWebSocketConfig(t *testing.T) {
 			LocalAddress:      item.localAddress,
 			WebSocketUsername: item.wsUsername,
 			WebSocketPassword: item.wsPassword,
-			WebSocketPaths:    item.wsPath,
 			ConnectionRetry:   item.connectionRetry,
 		}
 		err := config.ValidateWebSocketConfig()
@@ -131,15 +124,12 @@ func TestValidateWebSocketConfig(t *testing.T) {
 				LocalAddress:      item.localAddress,
 				WebSocketUsername: item.wsUsername,
 				WebSocketPassword: item.wsPassword,
-				WebSocketPaths:    item.wsPath,
 				ConnectionRetry:   item.connectionRetry,
 			}
 			if expectedConfig.LocalAddress == "" {
 				expectedConfig.LocalAddress = defaultRemoteMediationLocalAddress
 			}
-			if expectedConfig.WebSocketPaths == "" {
-				expectedConfig.WebSocketPaths = defaultRemoteMediationServerEndpoints
-			}
+			expectedConfig.WebSocketEndpoints = defaultRemoteMediationServerEndpoints
 			if expectedConfig.WebSocketUsername == "" {
 				expectedConfig.WebSocketUsername = defaultRemoteMediationServerUser
 			}
@@ -168,7 +158,6 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 					LocalAddress:      "http://127.0.0.1",
 					WebSocketUsername: rand.String(10),
 					WebSocketPassword: rand.String(10),
-					WebSocketPaths:    rand.String(10),
 					ConnectionRetry:   10,
 				},
 			},

--- a/pkg/mediationcontainer/mediation_container.go
+++ b/pkg/mediationcontainer/mediation_container.go
@@ -77,6 +77,11 @@ func InitMediationContainer(probeRegisteredMsg chan bool) {
 	remoteMediationClient.Init(probeRegisteredMsg)
 }
 
+func GetMediationService() string {
+	theContainer := singletonMediationContainer()
+	return theContainer.theRemoteMediationClient.Transport.GetService()
+}
+
 func CloseMediationContainer() {
 	glog.Infof("[CloseMediationContainer] Closing mediation container .....")
 	theContainer := singletonMediationContainer()

--- a/pkg/mediationcontainer/transport_endpoint.go
+++ b/pkg/mediationcontainer/transport_endpoint.go
@@ -5,6 +5,7 @@ type ITransport interface {
 	// Open
 	Connect() error
 	GetConnectionId() string
+	GetService() string
 	// Send
 	Send(messageToSend *TransportMessage) error
 	// Receive

--- a/pkg/probe/turbo_target_info.go
+++ b/pkg/probe/turbo_target_info.go
@@ -30,9 +30,14 @@ func (targetInfo *TurboTargetInfo) TargetIdentifierField() string {
 	return targetInfo.targetIdentifierField
 }
 
+func (targetInfo *TurboTargetInfo) String() string {
+	return targetInfo.targetCategory + " " + targetInfo.targetType +
+		" [" + targetInfo.targetIdentifierField + "]"
+}
+
 // Build an API target instance based on information from TurboTargetInfo.
 func (targetInfo *TurboTargetInfo) GetTargetInstance() *api.Target {
-	inputFields := []*api.InputField{}
+	var inputFields []*api.InputField
 	for _, acctValue := range targetInfo.accountValues {
 		inputFields = append(inputFields,
 			&api.InputField{

--- a/pkg/service/turbo_communication_config.go
+++ b/pkg/service/turbo_communication_config.go
@@ -18,8 +18,11 @@ type RestAPIConfig struct {
 }
 
 func (rc *RestAPIConfig) ValidRestAPIConfig() error {
-	if rc.OpsManagerUsername == "" || rc.OpsManagerPassword == "" {
-		return errors.New("Either username or password for API is not provided.")
+	// User should either specify neither username nor password, or
+	// specify both username and password
+	if (rc.OpsManagerUsername == "" && rc.OpsManagerPassword != "") ||
+		(rc.OpsManagerUsername != "" && rc.OpsManagerPassword == "") {
+		return errors.New("both username and password must be provided")
 	}
 	return nil
 }

--- a/pkg/service/turbo_communication_config_test.go
+++ b/pkg/service/turbo_communication_config_test.go
@@ -15,6 +15,11 @@ func TestValidateRestAPIConfig(t *testing.T) {
 	}{
 		{
 			user:      "",
+			password:  "",
+			expectErr: false,
+		},
+		{
+			user:      "",
 			password:  rand.String(5),
 			expectErr: true,
 		},
@@ -61,7 +66,6 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					LocalAddress:      "http://127.0.0.1",
 					WebSocketUsername: rand.String(10),
 					WebSocketPassword: rand.String(10),
-					WebSocketPaths:    rand.String(10),
 					ConnectionRetry:   10,
 				},
 				RestAPIConfig{
@@ -119,7 +123,7 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 		err := item.config.ValidateTurboCommunicationConfig()
 		if item.expectErr {
 			if err == nil {
-				t.Errorf("Expects error, but go no error: %v", item.config)
+				t.Errorf("Expects error, but go no error: %+v", item.config)
 			}
 		} else {
 			if err != nil {

--- a/pkg/service/turbo_communication_config_test.go
+++ b/pkg/service/turbo_communication_config_test.go
@@ -61,7 +61,7 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					LocalAddress:      "http://127.0.0.1",
 					WebSocketUsername: rand.String(10),
 					WebSocketPassword: rand.String(10),
-					WebSocketPath:     rand.String(10),
+					WebSocketPaths:    rand.String(10),
 					ConnectionRetry:   10,
 				},
 				RestAPIConfig{

--- a/vendor/github.com/davecgh/go-spew/LICENSE
+++ b/vendor/github.com/davecgh/go-spew/LICENSE
@@ -2,7 +2,7 @@ ISC License
 
 Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
 
-Permission to use, copy, modify, and distribute this software for any
+Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.
 

--- a/vendor/github.com/davecgh/go-spew/spew/bypasssafe.go
+++ b/vendor/github.com/davecgh/go-spew/spew/bypasssafe.go
@@ -16,7 +16,7 @@
 // when the code is running on Google App Engine, compiled by GopherJS, or
 // "-tags safe" is added to the go build command line.  The "disableunsafe"
 // tag is deprecated and thus should not be used.
-// +build js appengine safe disableunsafe
+// +build js appengine safe disableunsafe !go1.4
 
 package spew
 

--- a/vendor/github.com/davecgh/go-spew/spew/common.go
+++ b/vendor/github.com/davecgh/go-spew/spew/common.go
@@ -180,7 +180,7 @@ func printComplex(w io.Writer, c complex128, floatPrecision int) {
 	w.Write(closeParenBytes)
 }
 
-// printHexPtr outputs a uintptr formatted as hexidecimal with a leading '0x'
+// printHexPtr outputs a uintptr formatted as hexadecimal with a leading '0x'
 // prefix to Writer w.
 func printHexPtr(w io.Writer, p uintptr) {
 	// Null pointer.

--- a/vendor/github.com/davecgh/go-spew/spew/dump.go
+++ b/vendor/github.com/davecgh/go-spew/spew/dump.go
@@ -35,16 +35,16 @@ var (
 
 	// cCharRE is a regular expression that matches a cgo char.
 	// It is used to detect character arrays to hexdump them.
-	cCharRE = regexp.MustCompile("^.*\\._Ctype_char$")
+	cCharRE = regexp.MustCompile(`^.*\._Ctype_char$`)
 
 	// cUnsignedCharRE is a regular expression that matches a cgo unsigned
 	// char.  It is used to detect unsigned character arrays to hexdump
 	// them.
-	cUnsignedCharRE = regexp.MustCompile("^.*\\._Ctype_unsignedchar$")
+	cUnsignedCharRE = regexp.MustCompile(`^.*\._Ctype_unsignedchar$`)
 
 	// cUint8tCharRE is a regular expression that matches a cgo uint8_t.
 	// It is used to detect uint8_t arrays to hexdump them.
-	cUint8tCharRE = regexp.MustCompile("^.*\\._Ctype_uint8_t$")
+	cUint8tCharRE = regexp.MustCompile(`^.*\._Ctype_uint8_t$`)
 )
 
 // dumpState contains information about the state of a dump operation.
@@ -143,10 +143,10 @@ func (d *dumpState) dumpPtr(v reflect.Value) {
 	// Display dereferenced value.
 	d.w.Write(openParenBytes)
 	switch {
-	case nilFound == true:
+	case nilFound:
 		d.w.Write(nilAngleBytes)
 
-	case cycleFound == true:
+	case cycleFound:
 		d.w.Write(circularBytes)
 
 	default:

--- a/vendor/github.com/davecgh/go-spew/spew/format.go
+++ b/vendor/github.com/davecgh/go-spew/spew/format.go
@@ -182,10 +182,10 @@ func (f *formatState) formatPtr(v reflect.Value) {
 
 	// Display dereferenced value.
 	switch {
-	case nilFound == true:
+	case nilFound:
 		f.fs.Write(nilAngleBytes)
 
-	case cycleFound == true:
+	case cycleFound:
 		f.fs.Write(circularShortBytes)
 
 	default:

--- a/vendor/github.com/stretchr/testify/LICENSE
+++ b/vendor/github.com/stretchr/testify/LICENSE
@@ -1,22 +1,21 @@
-Copyright (c) 2012 - 2013 Mat Ryer and Tyler Bunnell
+MIT License
 
-Please consider promoting this project if you find it useful.
+Copyright (c) 2012-2018 Mat Ryer and Tyler Bunnell
 
-Permission is hereby granted, free of charge, to any person 
-obtaining a copy of this software and associated documentation 
-files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, 
-publish, distribute, sublicense, and/or sell copies of the Software, 
-and to permit persons to whom the Software is furnished to do so, 
-subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
-OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
-OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions.go
@@ -39,7 +39,7 @@ type ValueAssertionFunc func(TestingT, interface{}, ...interface{}) bool
 // for table driven tests.
 type BoolAssertionFunc func(TestingT, bool, ...interface{}) bool
 
-// ValuesAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
 // for table driven tests.
 type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
 
@@ -179,7 +179,11 @@ func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
 		return ""
 	}
 	if len(msgAndArgs) == 1 {
-		return msgAndArgs[0].(string)
+		msg := msgAndArgs[0]
+		if msgAsStr, ok := msg.(string); ok {
+			return msgAsStr
+		}
+		return fmt.Sprintf("%+v", msg)
 	}
 	if len(msgAndArgs) > 1 {
 		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
@@ -415,6 +419,17 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	return Fail(t, "Expected value not to be nil.", msgAndArgs...)
 }
 
+// containsKind checks if a specified kind in the slice of kinds.
+func containsKind(kinds []reflect.Kind, kind reflect.Kind) bool {
+	for i := 0; i < len(kinds); i++ {
+		if kind == kinds[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
 // isNil checks if a specified object is nil or not, without Failing.
 func isNil(object interface{}) bool {
 	if object == nil {
@@ -423,7 +438,14 @@ func isNil(object interface{}) bool {
 
 	value := reflect.ValueOf(object)
 	kind := value.Kind()
-	if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
+	isNilableKind := containsKind(
+		[]reflect.Kind{
+			reflect.Chan, reflect.Func,
+			reflect.Interface, reflect.Map,
+			reflect.Ptr, reflect.Slice},
+		kind)
+
+	if isNilableKind && value.IsNil() {
 		return true
 	}
 
@@ -1327,7 +1349,7 @@ func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
 }
 
 // diff returns a diff of both values as long as both are of the same type and
-// are a struct, map, slice or array. Otherwise it returns an empty string.
+// are a struct, map, slice, array or string. Otherwise it returns an empty string.
 func diff(expected interface{}, actual interface{}) string {
 	if expected == nil || actual == nil {
 		return ""
@@ -1345,7 +1367,7 @@ func diff(expected interface{}, actual interface{}) string {
 	}
 
 	var e, a string
-	if ek != reflect.String {
+	if et != reflect.TypeOf("") {
 		e = spewConfig.Sdump(expected)
 		a = spewConfig.Sdump(actual)
 	} else {

--- a/vendor/github.com/turbonomic/turbo-api/pkg/api/resource_type.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/api/resource_type.go
@@ -4,6 +4,8 @@ type ResourceType string
 
 const (
 	Resource_Type_Reservation     ResourceType = "reservations"
-	Resource_Type_Target          ResourceType = "targets"
+	Resource_Type_Targets         ResourceType = "targets"
+	Resource_Type_Target          ResourceType = "target"
+	Resource_Type_Probe           ResourceType = "probe"
 	Resource_Type_External_Target ResourceType = "externaltargets"
 )

--- a/vendor/github.com/turbonomic/turbo-api/pkg/api/type.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/api/type.go
@@ -24,6 +24,34 @@ type Target struct {
 	UUID string `json:"uuid,omitempty"`
 }
 
+// TargetInfo defines the protocols of the GET /target topology processor service
+type TargetInfo struct {
+	TargetID    int64       `json:"targetId,string"`
+	DisplayName string      `json:"displayName"`
+	TargetSpec  *TargetSpec `json:"spec"`
+}
+
+// TargetSpec defines the protocols of the POST /target topology processor service
+type TargetSpec struct {
+	// Probe to which the target belongs
+	ProbeID int64 `json:"probeId,string"`
+	// Is the target hidden from users
+	IsHidden bool `json:"isHidden"`
+	// Whether the target can be changed through APIs
+	ReadOnly bool `json:"readOnly"`
+	// The derived target ID associated with this target
+	DerivedTargetIDs []string `json:"derivedTargetIds"`
+	// Account values to use to add the target
+	InputFields []*InputField `json:"inputFields,omitempty"`
+}
+
+// ProbeDescription defines the protocols of the GET /probe topology-processor service
+type ProbeDescription struct {
+	ID       int64  `json:"id,string"`
+	Category string `json:"category"`
+	Type     string `json:"type"`
+}
+
 type InputField struct {
 	ClassName string `json:"className,omitempty"`
 
@@ -35,7 +63,7 @@ type InputField struct {
 	DisplayName string `json:"displayName,omitempty"`
 
 	// Group scope structure, filled if this field represents group scope value
-	GroupProperties []*List `json:"groupProperties,omitempty"`
+	GroupProperties []*List `json:"groupProperties"`
 
 	// Whether the field is mandatory. Valid targets must have all the mandatory fields set.
 	IsMandatory bool `json:"isMandatory,omitempty"`
@@ -52,7 +80,7 @@ type InputField struct {
 	Value string `json:"value,omitempty"`
 
 	// Type of the value this field holds = ['STRING', 'BOOLEAN', 'NUMERIC', 'GROUP_SCOPE']
-	ValueType string `json:"valueType:omitempty"`
+	ValueType string `json:"valueType,omitempty"`
 
 	// The regex pattern that needs to be satisfied for the input field text
 	VerificationRegex string `json:"verificationRegex,omitempty"`

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
@@ -1,17 +1,15 @@
 package client
 
 import (
-	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
-
 	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-api/pkg/api"
+	"net/http"
 )
 
-type Client struct {
+// APIClient connects to api service through ingress
+type APIClient struct {
 	*RESTClient
 	SessionCookie *http.Cookie
 }
@@ -20,25 +18,75 @@ const (
 	SessionCookie string = "JSESSIONID"
 )
 
-// Create a Turbo API Client based on basic authentication.
-func NewAPIClientWithBA(c *Config) (*Client, error) {
-	if c.basicAuth == nil {
-		return nil, errors.New("Basic authentication is not set")
+// Discover a target using API
+// This function is called by turboctl which is not being maintained
+func (c *APIClient) DiscoverTarget(uuid string) (*Result, error) {
+	response, err := c.Post().Resource(api.Resource_Type_Targets).Name(uuid).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover target %s: %s", uuid, err)
 	}
-	client := http.DefaultClient
-	// If use https, disable the security check.
-	if c.serverAddress.Scheme == "https" {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		client = &http.Client{Transport: tr}
+	if response.statusCode != 200 {
+		return nil, buildResponseError("target discovery", response.status, response.body)
 	}
-	restClient := NewRESTClient(client, c.serverAddress, c.apiPath).BasicAuthentication(c.basicAuth)
-	return &Client{restClient, nil}, nil
+	return &response, nil
+}
+
+// AddTarget adds a target via api service
+func (c *APIClient) AddTarget(target *api.Target) error {
+	// Login first
+	if _, err := c.login(); err != nil {
+		return fmt.Errorf("failed to login: %v", err)
+	}
+
+	// Find if the target exists
+	targetExists, _ := c.findTarget(target)
+	if targetExists {
+		glog.V(2).Infof("Target %v already exists.", getTargetId(target))
+		return nil
+	}
+
+	// Construct the Target required by the rest api
+	targetData, err := json.Marshal(target)
+	if err != nil {
+		return fmt.Errorf("failed to marshall target instance: %v", err)
+	}
+
+	// Create the rest api request
+	request := c.Post().Resource(api.Resource_Type_Targets).
+		Header("Content-Type", "application/json").
+		Header("Accept", "application/json").
+		Header("Cookie", fmt.Sprintf("%s=%s", c.SessionCookie.Name, c.SessionCookie.Value)).
+		Data(targetData)
+
+	glog.V(4).Infof("[AddTarget] %v.", request)
+	glog.V(4).Infof("[AddTarget] Data: %s.", targetData)
+
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return fmt.Errorf("request %v failed: %s", request, err)
+	}
+	glog.V(4).Infof("Response %+v.", response)
+
+	if response.statusCode != 200 {
+		return buildResponseError("target addition", response.status, response.body)
+	}
+
+	glog.V(2).Infof("Successfully added target via API service: %v.", response)
+	return nil
 }
 
 // Login to the Turbo API server
-func (c *Client) Login() (*Result, error) {
+func (c *APIClient) login() (*Result, error) {
+	if c.SessionCookie != nil {
+		// Already logged in
+		return nil, nil
+	}
+	if c.basicAuth == nil ||
+		c.basicAuth.username == "" ||
+		c.basicAuth.password == "" {
+		return nil, fmt.Errorf("missing username and password")
+	}
 	var data []byte
 	data = []byte(fmt.Sprintf("username=%s&password=%s", c.basicAuth.username, c.basicAuth.password))
 	request := c.Post().Resource("login").
@@ -57,81 +105,30 @@ func (c *Client) Login() (*Result, error) {
 	sessionCookie, ok := response.cookies[SessionCookie]
 	if ok {
 		c.SessionCookie = sessionCookie
-		glog.V(4).Infof("Session Cookie = %s:%s\n", c.SessionCookie.Name, c.SessionCookie.Value)
+		glog.V(2).Infof("Successfully logged in to Turbonomic server.")
+		glog.V(4).Infof("Session Cookie = %s:%s.", c.SessionCookie.Name, c.SessionCookie.Value)
 	} else {
-		return nil, buildResponseError("Invalid session cookie", response.status, fmt.Sprintf("%s", response.cookies))
+		return nil, buildResponseError("Invalid session cookie", response.status,
+			fmt.Sprintf("%s", response.cookies))
 	}
 	return &response, nil
 }
 
-// Discover a target using API
-func (c *Client) DiscoverTarget(uuid string) (*Result, error) {
-	response, err := c.Post().Resource(api.Resource_Type_Target).Name(uuid).Do()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to discover target %s: %s", uuid, err)
-	}
-	if response.statusCode != 200 {
-		return nil, buildResponseError("target discovery", response.status, response.body)
-	}
-	return &response, nil
-}
-
-//Add a target using API
-func (c *Client) AddTarget(target *api.Target) (*Result, error) {
-	if c.SessionCookie == nil {
-		return nil, fmt.Errorf("Null login session cookie\n")
-	}
-
-	// Find if the target exists - this is a workaround since in current XL server,
-	// duplicate targets can be added
-	targetExists, _ := c.FindTarget(target)
-	if targetExists {
-		return nil, fmt.Errorf("Target %v exists", target)
-	}
-
-	glog.V(2).Infof("***************** [AddTarget] %++v\n", target)
-
-	// Create the rest api request
-	targetData, err := json.Marshal(target)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to marshall target instance: %s", err)
-	}
-
-	request := c.Post().Resource(api.Resource_Type_Target).
-		Header("Content-Type", "application/json").
-		Header("Accept", "application/json").
-		Header("Cookie", fmt.Sprintf("%s=%s", c.SessionCookie.Name, c.SessionCookie.Value)).
-		Data(targetData)
-
-	glog.V(4).Infof("[AddTarget] Request %++v\n", request)
-
-	response, err := request.Do()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to add target: %s", err)
-	}
-	if response.statusCode != 200 {
-		return nil, buildResponseError("target addition", response.status, response.body)
-	}
-
-	return &response, nil
-}
-
-//Find if the given target exists within the Turbo server
-func (c *Client) FindTarget(target *api.Target) (bool, error) {
+func (c *APIClient) findTarget(target *api.Target) (bool, error) {
 	// Get a list of targets from the Turbo server
-	request := c.Get().Resource(api.Resource_Type_Target).
+	request := c.Get().Resource(api.Resource_Type_Targets).
 		Header("Content-Type", "application/json").
 		Header("Accept", "application/json").
 		Header("Cookie", fmt.Sprintf("%s=%s", c.SessionCookie.Name, c.SessionCookie.Value))
 
-	glog.V(4).Infof("[FindTarget] Request %++v\n", request)
-
 	response, err := request.Do()
-
 	if err != nil {
-		fmt.Printf("Failed to execute find target request: %s", err)
-		return false, fmt.Errorf("Failed to execute find target request: %s", err)
+		glog.Errorf("Failed to execute find target request: %s.", err)
+		return false, fmt.Errorf("failed to execute find target request: %v", err)
 	}
+
+	glog.V(4).Infof("Received response from find target request %v: %+v.",
+		request, response)
 
 	if response.statusCode != 200 {
 		return false, buildResponseError("find target", response.status, response.body)
@@ -142,7 +139,9 @@ func (c *Client) FindTarget(target *api.Target) (bool, error) {
 
 	// Parse the response - list of targets
 	var targetList []interface{}
-	json.Unmarshal([]byte(response.body), &targetList)
+	if err := json.Unmarshal([]byte(response.body), &targetList); err != nil {
+		return false, fmt.Errorf("failed to unmarshall find target response: %v", err)
+	}
 
 	// Iterate over the list of targets to look for the given target
 	// by comparing the category, target type and identifier fields
@@ -171,32 +170,10 @@ func (c *Client) FindTarget(target *api.Target) (bool, error) {
 				}
 			}
 		}
-		glog.V(4).Infof("%s::%s::%s\n", category, targetType, tgtId)
+		glog.V(4).Infof("%s::%s::%s", category, targetType, tgtId)
 		if target.Category == category && target.Type == targetType && tgtId == targetId {
 			return true, nil
 		}
 	}
 	return false, nil
-}
-
-// Get the target identifier for the given target
-func getTargetId(target *api.Target) string {
-	for _, inputField := range target.InputFields {
-		field := inputField.Name
-		if field == "targetIdentifier" {
-			tgtId := inputField.Value
-			return tgtId
-		}
-	}
-	return ""
-}
-
-func buildResponseError(requestDesc string, status string, content string) error {
-	errorMsg := fmt.Sprintf("unsuccessful %s response: %s.", requestDesc, status)
-	errorDTO, err := parseAPIErrorDTO(content)
-	if err == nil && errorDTO.Message != "" {
-		// Add error message only if we can parse result content to errorDTO.
-		errorMsg = errorMsg + fmt.Sprintf(" %s.", errorDTO.Message)
-	}
-	return fmt.Errorf("%s", errorMsg)
 }

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/client.go
@@ -1,0 +1,137 @@
+package client
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/turbonomic/turbo-api/pkg/api"
+)
+
+var (
+	API                   = "api"
+	TopologyProcessor     = "topology-processor"
+	APIPath               = "/vmturbo/rest/"
+	TopologyProcessorPath = "/"
+
+	defaultRESTAPIEndpoints = map[string]string{
+		API:               APIPath,
+		TopologyProcessor: TopologyProcessorPath,
+	}
+)
+
+type Client interface {
+	AddTarget(target *api.Target) error
+	DiscoverTarget(uuid string) (*Result, error)
+}
+
+// TurboClient manages REST clients to Turbonomic services
+type TurboClient struct {
+	clients map[string]Client // A map that maps service name to REST client
+}
+
+func NewTurboClient(c *Config) (*TurboClient, error) {
+	// Build httpClient, which can be shared by multiple connections
+	httpClient := http.DefaultClient
+	proxy := c.proxy
+	if proxy != "" || c.serverAddress.Scheme == "https" {
+		var tr http.Transport
+		if c.serverAddress.Scheme == "https" {
+			tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+
+		if proxy != "" {
+			//Check if the proxy server requires authentication or not
+			//Authenticated proxy format: http://username:password@ip:port
+			//Non-Aunthenticated proxy format: http://ip:port
+			if strings.Index(proxy, "@") != -1 {
+				//Extract the username password portion, with @
+				usernamePassword := proxy[strings.Index(proxy, "//")+2 : strings.LastIndex(proxy, "@")+1]
+				username := usernamePassword[:strings.Index(usernamePassword, ":")]
+				password := usernamePassword[strings.Index(usernamePassword, ":")+1 : strings.LastIndex(usernamePassword, "@")]
+				//Extract Proxy address by remove the username_password
+				proxyAddr := strings.ReplaceAll(proxy, usernamePassword, "")
+				proxyURL, err := url.Parse(proxyAddr)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to parse proxy\n")
+				}
+				proxyURL.User = url.UserPassword(username, password)
+				tr.Proxy = http.ProxyURL(proxyURL)
+			} else {
+				proxyURL, err := url.Parse(proxy)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to parse proxy\n")
+				}
+				tr.Proxy = http.ProxyURL(proxyURL)
+			}
+		}
+		httpClient = &http.Client{Transport: &tr}
+	}
+	// Build the map of clients
+	turboClient := &TurboClient{
+		clients: make(map[string]Client),
+	}
+	for service, endpoint := range defaultRESTAPIEndpoints {
+		turboClient.clients[service] = newClient(httpClient, c.serverAddress,
+			c.basicAuth, service, endpoint)
+	}
+	return turboClient, nil
+}
+
+func newClient(client *http.Client, baseURL *url.URL, basicAuth *BasicAuthentication,
+	service, endpoint string) Client {
+	restClient := NewRESTClient(client, baseURL, endpoint).BasicAuthentication(basicAuth)
+	if service == TopologyProcessor {
+		// Create a Turbo client without authentication
+		return &TPClient{
+			restClient,
+		}
+	}
+	// Create a Turbo client based on basic authentication
+	return &APIClient{
+		restClient.BasicAuthentication(basicAuth),
+		nil,
+	}
+}
+
+// AddTarget adds a target via a given service
+func (turboClient *TurboClient) AddTarget(target *api.Target, service string) error {
+	client, ok := turboClient.clients[service]
+	if !ok {
+		return fmt.Errorf("client for service %v is not registered", service)
+	}
+	return client.AddTarget(target)
+}
+
+// AddTarget discovers a target via a given service
+func (turboClient *TurboClient) DiscoverTarget(uuid, service string) (*Result, error) {
+	client, ok := turboClient.clients[service]
+	if !ok {
+		return nil, fmt.Errorf("client for service %v is not registered", service)
+	}
+	return client.DiscoverTarget(uuid)
+}
+
+// Get the target identifier for the given target
+func getTargetId(target *api.Target) string {
+	for _, inputField := range target.InputFields {
+		field := inputField.Name
+		if field == "targetIdentifier" {
+			tgtId := inputField.Value
+			return tgtId
+		}
+	}
+	return ""
+}
+
+func buildResponseError(requestDesc string, status string, content string) error {
+	errorMsg := fmt.Sprintf("unsuccessful %s response: %s.", requestDesc, status)
+	errorDTO, err := parseAPIErrorDTO(content)
+	if err == nil && errorDTO.Message != "" {
+		// Add error message only if we can parse result content to errorDTO.
+		errorMsg = errorMsg + fmt.Sprintf(" %s.", errorDTO.Message)
+	}
+	return fmt.Errorf("%s", errorMsg)
+}

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/config.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/config.go
@@ -4,24 +4,19 @@ import (
 	"net/url"
 )
 
-const (
-	defaultAPIPath = "vmturbo/rest/"
-)
-
 type Config struct {
 	// ServerAddress is A URL, including <Scheme>://<IP>:<Port>.
 	serverAddress *url.URL
-	// APIPath is a sub-path that points to an API root.
-	apiPath string
-
 	// For Basic authentication.
 	basicAuth *BasicAuthentication
+	// For proxy
+	proxy string
 }
 
 type ConfigBuilder struct {
 	serverAddress *url.URL
-	apiPath       string
 	basicAuth     *BasicAuthentication
+	proxy         string
 }
 
 func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
@@ -30,8 +25,8 @@ func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
 	}
 }
 
-func (cb *ConfigBuilder) APIPath(apiPath string) *ConfigBuilder {
-	cb.apiPath = apiPath
+func (cb *ConfigBuilder) SetProxy(proxy string) *ConfigBuilder {
+	cb.proxy = proxy
 	return cb
 }
 
@@ -46,13 +41,7 @@ func (cb *ConfigBuilder) BasicAuthentication(usrn, passd string) *ConfigBuilder 
 func (cb *ConfigBuilder) Create() *Config {
 	return &Config{
 		serverAddress: cb.serverAddress,
-		// If API path not specified, use the default API path.
-		apiPath: func() string {
-			if cb.apiPath == "" {
-				return defaultAPIPath
-			}
-			return cb.apiPath
-		}(),
-		basicAuth: cb.basicAuth,
+		basicAuth:     cb.basicAuth,
+		proxy:         cb.proxy,
 	}
 }

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/request.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/request.go
@@ -199,6 +199,10 @@ func (r *Request) request(fn func(*http.Response)) error {
 	return nil
 }
 
+func (r *Request) String() string {
+	return fmt.Sprintf("Request: %s %v Headers: %v", r.verb, r.URL(), r.headers)
+}
+
 func parseHTTPResponse(resp *http.Response) Result {
 	if resp == nil {
 		return Result{
@@ -217,7 +221,7 @@ func parseHTTPResponse(resp *http.Response) Result {
 	content, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return Result{
-			err: fmt.Errorf("Error reading response body: %++v", err),
+			err: fmt.Errorf("error reading response body: %v", err),
 		}
 	}
 

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/tp_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/tp_client.go
@@ -1,0 +1,163 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-api/pkg/api"
+)
+
+// TPClient connects to topology processor service
+type TPClient struct {
+	*RESTClient
+}
+
+// DiscoverTarget adds a target via Topology Processor service
+func (c *TPClient) DiscoverTarget(uuid string) (*Result, error) {
+	// Not implemented
+	return &Result{}, nil
+}
+
+// AddTarget adds a target via topology processor service
+func (c *TPClient) AddTarget(target *api.Target) error {
+	// Check if the given target already exists
+	targetName := getTargetId(target)
+	targetID, err := c.findTargetID(targetName)
+	if err == nil && targetID > 0 {
+		glog.V(2).Infof("Target %v already exists with ID %v.",
+			targetName, targetID)
+		return nil
+	}
+
+	if err != nil {
+		glog.V(4).Infof("Cannot find target %v: %v", targetName, err)
+	}
+
+	// Get the Probe ID based on probe type and probe category
+	probeID, err := c.getProbeID(target.Type, target.Category)
+	if err != nil {
+		return fmt.Errorf("failed to get probe ID: %v", err)
+	}
+
+	// Add the target which belongs to the probe with the given probeID
+	glog.V(2).Infof("Starting to add target %v for probe %v with ID : %v",
+		targetName, target.Type, probeID)
+
+	// Construct the TargetSpec required by the rest api
+	targetSpec := &api.TargetSpec{
+		ProbeID:          probeID,
+		DerivedTargetIDs: []string{},
+		InputFields:      target.InputFields,
+	}
+
+	// Create the rest api request
+	targetData, err := json.Marshal(targetSpec)
+	if err != nil {
+		return fmt.Errorf("failed to marshall target spec: %v", err)
+	}
+	request := c.Post().Resource(api.Resource_Type_Target).
+		Header("Content-Type", "application/json;charset=UTF-8").
+		Header("Accept", "application/json;charset=UTF-8").
+		Data(targetData)
+
+	glog.V(4).Infof("[AddTarget] %v", request)
+	glog.V(4).Infof("[AddTarget] Data: %s", targetData)
+
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return fmt.Errorf("request %v failed: %s", request, err)
+	}
+	glog.V(4).Infof("Response %+v", response)
+
+	if response.statusCode != 200 {
+		return buildResponseError("target addition", response.status, response.body)
+	}
+
+	// Unmarshal the response and parse out the target ID
+	var targetInfo api.TargetInfo
+	_ = json.Unmarshal([]byte(response.body), &targetInfo)
+	glog.V(2).Infof("Successfully added target via Topology Processor service. Target ID: %v",
+		targetInfo.TargetID)
+
+	return nil
+}
+
+func (c *TPClient) findTargetID(targetName string) (int64, error) {
+	// Get a list of targets from the Turbo server
+	request := c.Get().Resource(api.Resource_Type_Target).
+		Header("Content-Type", "application/json").
+		Header("Accept", "application/json")
+
+	response, err := request.Do()
+	if err != nil {
+		return 0, fmt.Errorf("failed to execute find target request %v: %v",
+			request, err)
+	}
+
+	glog.V(4).Infof("Received response from find target request %v: %+v",
+		request, response)
+
+	if response.statusCode != 200 {
+		return 0, buildResponseError("find target", response.status, response.body)
+	}
+
+	var targetsMap map[string][]api.TargetInfo
+	if err := json.Unmarshal([]byte(response.body), &targetsMap); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal get target response: %v", err)
+	}
+	glog.V(4).Infof("Successfully parsed response body into targetsMap: %v",
+		spew.Sdump(targetsMap))
+	targets, found := targetsMap["targets"]
+	if !found {
+		return 0, fmt.Errorf("failed to find key \"targets\" from response")
+	}
+
+	for _, target := range targets {
+		if target.TargetSpec == nil {
+			continue
+		}
+		for _, inputField := range target.TargetSpec.InputFields {
+			if inputField.Name == "targetIdentifier" &&
+				inputField.Value == targetName {
+				return target.TargetID, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("target %v does not exist", targetName)
+}
+
+func (c *TPClient) getProbeID(probeType, probeCategory string) (int64, error) {
+	request := c.Get().Resource(api.Resource_Type_Probe).
+		Header("Content-Type", "application/json").
+		Header("Accept", "application/json")
+	response, err := request.Do()
+	if err != nil {
+		return 0, fmt.Errorf("failed to execute get probe request %+v: %v",
+			request, err)
+	}
+	glog.V(4).Infof("Received response from get probe request %+v: %+v",
+		request, response)
+	if response.statusCode != 200 {
+		return 0, buildResponseError("get probe", response.status, response.body)
+	}
+	// Parse the response - list of probes
+	var probesMap map[string][]api.ProbeDescription
+	if err := json.Unmarshal([]byte(response.body), &probesMap); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal get probe response: %v", err)
+	}
+	probes, found := probesMap["probes"]
+	if !found {
+		return 0, fmt.Errorf("failed to find key \"probes\" from response")
+	}
+	for _, probe := range probes {
+		if probe.Category == probeCategory &&
+			probe.Type == probeType {
+			return probe.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("failed to find probe with category %v and type %v",
+		probeCategory, probeType)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,6 +10,6 @@ github.com/gorilla/websocket
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.3.0
 github.com/stretchr/testify/assert
-# github.com/turbonomic/turbo-api v0.0.0-20200409182717-9a979f01a6bb
+# github.com/turbonomic/turbo-api v0.0.0-20200413140231-3bef8fb11708
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,0 +1,15 @@
+# github.com/davecgh/go-spew v1.1.1
+github.com/davecgh/go-spew/spew
+# github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+github.com/golang/glog
+# github.com/golang/protobuf v1.3.1
+github.com/golang/protobuf/proto
+# github.com/gorilla/websocket v1.2.0
+github.com/gorilla/websocket
+# github.com/pmezard/go-difflib v1.0.0
+github.com/pmezard/go-difflib/difflib
+# github.com/stretchr/testify v1.3.0
+github.com/stretchr/testify/assert
+# github.com/turbonomic/turbo-api v0.0.0-20200409182717-9a979f01a6bb
+github.com/turbonomic/turbo-api/pkg/api
+github.com/turbonomic/turbo-api/pkg/client


### PR DESCRIPTION
This PR depends on https://github.com/turbonomic/turbo-api/pull/7. 

This PR changes `turbo-go-sdk` to allow adding target through either `api` or `topology-processor` service. The following is the flow:

* The `configmap` `serverURL` should only specify the scheme (http/https), host, port, same as today. No subpath (custom URL) should be specified.
* During probe registration, try API endpoint at `serverURL/vmturbo/remoteMediation`, if successful, we know the service is an API endpoint.
* Otherwise, try TP endpoint at `serverURL/remoteMediation`, if successful, we know the service is a TP endpoint.
* If a `targetName` is defined, then add target through the proper endpoint. i.e., for TP endpoint, do `POST serverURL/target`, for API endpoint, do login first, then do `POST serverURL/vmturbo/rest/targets`.

Implementation:
* The the following custom URL logic is removed.
```
	// If the path specified for the platform use it instead of assuming the default /vmturbo/remoteMediation
	if serverURL.Path != "" && serverURL.Path != "/" {
		wsConfig.WebSocketPath = ""
	}
```
* `OpsManagerUsername` and `OpsManagerPassword` are not mandatory anymore.
* Rename the method receiver for `ClientWebSocketTransport` to `wsTransport`, so that they are consistent across all methods.
* The retry/fallback logic for websocket connection is in the `openWebSocketConn()` function. The function returns a service name indicating which service it has successfully connected to. Later on the service name is passed to the `TurboClient.AddTarget()` call to advise on which service to call to add a target. 
* Improve logging messages.
* Fix/add unit tests.

Please ignore changes to the `go.mod`, `go.sum` and `vendor`, they will be updated when `turbo-api` pull request is merged.

The following is a snippet of `kubeturbo` logging illustrating the retry/fallback logic:
```
I0409 16:04:48.334569       1 kubeturbo_builder.go:289] ********** Start running Kubeturbo Service **********
I0409 16:04:48.334807       1 mediation_container.go:67] Initializing mediation container .....
I0409 16:04:48.334820       1 mediation_container.go:74] Registering 1 probes
I0409 16:04:48.334842       1 client_websocket_transport.go:371] Trying websocket connection to: wss://topologyprocessor-turbonomic.apps.cititest.openshift-turbonomic.net/vmturbo/remoteMediation
E0409 16:04:48.360257       1 client_websocket_transport.go:379] Failed to connect to server(wss://topologyprocessor-turbonomic.apps.cititest.openshift-turbonomic.net/vmturbo/remoteMediation): websocket: bad handshake
I0409 16:04:48.360518       1 client_websocket_transport.go:371] Trying websocket connection to: wss://topologyprocessor-turbonomic.apps.cititest.openshift-turbonomic.net/remoteMediation
I0409 16:04:48.372417       1 client_websocket_transport.go:374] Successfully connected to topology-processor service at: wss://topologyprocessor-turbonomic.apps.cititest.openshift-turbonomic.net/remoteMediation
I0409 16:04:48.372432       1 client_websocket_transport.go:293] Connected to server 184.72.14.233:443::10.128.3.105:36652
I0409 16:04:48.372435       1 client_websocket_transport.go:294] WebSocket transport layer is ready.
I0409 16:04:48.372448       1 remote_mediation_client.go:90] Start sdk client protocol ........
I0409 16:04:48.372453       1 sdk_client_protocol.go:32] Starting protocol negotiation ....
I0409 16:04:48.373674       1 sdk_client_protocol.go:115] Protocol negotiation result: ACCEPTED. Protocol version "7.21" is allowed to interact with server.
I0409 16:04:48.373702       1 sdk_client_protocol.go:41] Starting probe registration ....
I0409 16:04:48.373709       1 sdk_client_protocol.go:163] SdkClientProtocol] Creating Probe Info for Kubernetes-xl-aws-ocp
I0409 16:04:48.377177       1 sdk_client_protocol.go:155] Probe registration succeeded.
I0409 16:04:48.397395       1 tp_client.go:39] Starting to add target Kubernetes-xl-aws-ocp for probe Kubernetes-xl-aws-ocp with ID : 73414821487456
I0409 16:04:48.409082       1 tp_client.go:73] Successfully added target via Topology Processor service. Target ID: 73415587431120
I0409 16:04:48.409829       1 remote_mediation_client.go:212] [handleServerMessages][ServerRequestEndpoint] : received message with request type Discovery.
``` 