### PR TITLE
Add layeredOver and consistsOf to entity dto builder and add active bool to commodity dto builder

### DIFF
--- a/pkg/builder/commodity_dto_builder.go
+++ b/pkg/builder/commodity_dto_builder.go
@@ -115,6 +115,14 @@ func (cb *CommodityDTOBuilder) Reservation(reservation float64) *CommodityDTOBui
 	return cb
 }
 
+func (cb *CommodityDTOBuilder) Active(active bool) *CommodityDTOBuilder {
+	if cb.err != nil {
+		return cb
+	}
+	cb.active = &active
+	return cb
+}
+
 func (cb *CommodityDTOBuilder) Resizable(resizable bool) *CommodityDTOBuilder {
 	if cb.err != nil {
 		return cb

--- a/pkg/builder/commodity_dto_builder_test.go
+++ b/pkg/builder/commodity_dto_builder_test.go
@@ -193,6 +193,42 @@ func TestCommodityDTOBuilder_Capacity(t *testing.T) {
 	}
 }
 
+func TestCommodityDTOBuilder_Active(t *testing.T) {
+	table := []struct {
+		active      bool
+		existingErr error
+	}{
+		{
+			existingErr: fmt.Errorf("Fake"),
+			active:      mathrand.Int31n(2) == 1,
+		},
+		{
+			active: true,
+		},
+		{
+			active: false,
+		},
+	}
+	for _, item := range table {
+		base := randomBaseCommodityDTOBuilder()
+		var active *bool
+		if item.existingErr != nil {
+			base.err = item.existingErr
+		} else {
+			active = &item.active
+		}
+		expectedBuilder := &CommodityDTOBuilder{
+			commodityType: base.commodityType,
+			active:        active,
+			err:           item.existingErr,
+		}
+		builder := base.Active(item.active)
+		if !reflect.DeepEqual(builder, expectedBuilder) {
+			t.Errorf("\nExpected %+v, \ngot      %+v", expectedBuilder, builder)
+		}
+	}
+}
+
 func TestCommodityDTOBuilder_Resizable(t *testing.T) {
 	table := []struct {
 		resizable   bool

--- a/pkg/builder/entity_dto_builder.go
+++ b/pkg/builder/entity_dto_builder.go
@@ -78,6 +78,8 @@ type EntityDTOBuilder struct {
 	notification          []*proto.NotificationDTO
 	keepStandalone        *bool
 	profileID             *string
+	layeredOver           []string
+	consistsOf            []string
 
 	// Action Eligibility related
 	actionEligibility *ActionEligibility
@@ -142,6 +144,8 @@ func (eb *EntityDTOBuilder) Create() (*proto.EntityDTO, error) {
 		ProviderPolicy:        eb.providerPolicy,
 		OwnedBy:               eb.ownedBy,
 		Notification:          eb.notification,
+		LayeredOver:           eb.layeredOver,
+		ConsistsOf:            eb.consistsOf,
 	}
 	if eb.storageData != nil {
 		entityDTO.EntityData = &proto.EntityDTO_StorageData_{eb.storageData}
@@ -342,6 +346,22 @@ func (eb *EntityDTOBuilder) ConsumerPolicy(cp *proto.EntityDTO_ConsumerPolicy) *
 		return eb
 	}
 	eb.consumerPolicy = cp
+	return eb
+}
+
+func (eb *EntityDTOBuilder) LayeredOver(layeredOver []string) *EntityDTOBuilder {
+	if eb.err != nil {
+		return eb
+	}
+	eb.layeredOver = layeredOver
+	return eb
+}
+
+func (eb *EntityDTOBuilder) ConsistsOf(consistsOf []string) *EntityDTOBuilder {
+	if eb.err != nil {
+		return eb
+	}
+	eb.consistsOf = consistsOf
 	return eb
 }
 

--- a/pkg/builder/entity_dto_builder_test.go
+++ b/pkg/builder/entity_dto_builder_test.go
@@ -284,6 +284,74 @@ func TestEntityDTOBuilder_Monitored(t *testing.T) {
 	}
 }
 
+func TestEntityDTOBuilder_LayeredOver(t *testing.T) {
+	table := []struct {
+		layeredOver []string
+		existingErr error
+	}{
+		{
+			layeredOver: []string{rand.String(5)},
+			existingErr: fmt.Errorf("Error"),
+		},
+		{
+			layeredOver: []string{rand.String(5)},
+		},
+	}
+	for _, item := range table {
+		base := randomBaseEntityDTOBuilder()
+		expectedBuilder := &EntityDTOBuilder{
+			entityType:        base.entityType,
+			id:                base.id,
+			actionEligibility: testNewActionEligibility(),
+			providerMap:       make(map[string]proto.EntityDTO_EntityType),
+		}
+		if item.existingErr != nil {
+			base.err = item.existingErr
+			expectedBuilder.err = item.existingErr
+		} else {
+			expectedBuilder.layeredOver = item.layeredOver
+		}
+		builder := base.LayeredOver(item.layeredOver)
+		if !reflect.DeepEqual(builder, expectedBuilder) {
+			t.Errorf("Expected %+v, got %+v", expectedBuilder, builder)
+		}
+	}
+}
+
+func TestEntityDTOBuilder_ConsistsOf(t *testing.T) {
+	table := []struct {
+		consistsOf  []string
+		existingErr error
+	}{
+		{
+			consistsOf:  []string{rand.String(5)},
+			existingErr: fmt.Errorf("Error"),
+		},
+		{
+			consistsOf: []string{rand.String(5)},
+		},
+	}
+	for _, item := range table {
+		base := randomBaseEntityDTOBuilder()
+		expectedBuilder := &EntityDTOBuilder{
+			entityType:        base.entityType,
+			id:                base.id,
+			actionEligibility: testNewActionEligibility(),
+			providerMap:       make(map[string]proto.EntityDTO_EntityType),
+		}
+		if item.existingErr != nil {
+			base.err = item.existingErr
+			expectedBuilder.err = item.existingErr
+		} else {
+			expectedBuilder.consistsOf = item.consistsOf
+		}
+		builder := base.ConsistsOf(item.consistsOf)
+		if !reflect.DeepEqual(builder, expectedBuilder) {
+			t.Errorf("Expected %+v, got %+v", expectedBuilder, builder)
+		}
+	}
+}
+
 func TestEntityDTOBuilder_ApplicationData(t *testing.T) {
 	table := []struct {
 		appData *proto.EntityDTO_ApplicationData


### PR DESCRIPTION
**Intent**:
The intent is to add support in turbo go SDK to allow kubeturbo to set up entity DTOs with `layeredOver` and `consistsOf` relationships and set up "inactive" commodity DTOs.

**Background**:
In the new container model, we have created 2 new entity types: `WorkloadController` and `ContainerSpec`. We want to have:
```
WorkloadController owns ContainerSpec
ContainerSpec aggregates Container replicas
```
so that the 3 entities can be connected in the supply chain. There are no commodities sold or bought between these entities.

The turbo SDK does not yet provide support for specifying these connections. We can make use of the same mechanism used by Cloud probes:
1. Set up `LayeredOver` and `ConsistsOf` relationships in the discovery
2. In a custom stitching stage, platform will translate these relationships into `aggregate` and `own`.

So we'll have
```
CONTAINER entities should be LayeredOver their associated CONTAINER_SPEC
  The platform will translate this into the following relation:
    CONTAINER_SPEC aggregates CONTAINER
WORKLOAD_CONTROLLER entities should have ConsistsOf relations to all their associated CONTAINER_SPEC entities
  The platform will translate this into the following relation:
    CONTROLLER owns CONTAINER_SPEC
```

**Implementation**:
1. To allow kubeturbo create entity DTOs with `ConsistsOf` and `LayeredOver`, add these 2 functions in `entity_dto_builder`
2. Additionally, VCPU and VMem commodities sold by ContainerSpecs are designed to model the shared utilization among all container replicas specified by the ContainerSpec. We don't want these commodities sold by ContainerSpecs analyzed by turbo Market engine so they should be "inactive". To allow setting commodity DTOs as inactive, add `Active` function in `commodity_dto_builder`

The corresponding kubeturbo changes to set up these fields are based on the creation of WorkloadController entities in this PR: https://github.com/turbonomic/kubeturbo/pull/401

Will create the PR for populating these relationships in kubeturbo once the changes of WorkloadController creation are merged.