### PR TITLE
Allow probe to continue when registration fails

### DIFF
--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -35,8 +35,6 @@ func (tapService *TAPService) addTarget(isRegistered chan bool) {
 	case status := <-isRegistered:
 		if !status {
 			glog.Errorf("Probe %v registration failed.", pinfo)
-			close(tapService.disconnectFromTurbo)
-			glog.Errorf("Notified to close TAP service.")
 			return
 		}
 		break


### PR DESCRIPTION
Soon we are going to release `kubeturbo` that supports ARM model (i.e., 7.22.4). This version of `kubeturbo` is not compatible with older version of Turbonomic server. If the customer upgrades `kubeturbo` to 7.22.4 without upgrading the Turbonomic server (e.g., 7.22.2), he will see that `kubeturbo` panic, and in a `CrashLoopBackoff` state:

```
I0617 18:57:54.631582       1 sdk_client_protocol.go:41] Starting probe registration ....
I0617 18:57:54.631598       1 sdk_client_protocol.go:163] SdkClientProtocol] Creating Probe Info for Kubernetes-Turbonomic
E0617 18:58:24.754488       1 sdk_client_protocol.go:72] [RegistrationEndpoint]: wait for message from channel timeout(30 seconds)
E0617 18:58:24.796853       1 sdk_client_protocol.go:144] [RegistrationEndpoint] : read Registration response from channel failed: [RegistrationEndpoint]: wait for message from channel timeout(30 seconds)
E0617 18:58:24.796892       1 sdk_client_protocol.go:44] Failure during Registration, cannot receive server messages
E0617 18:58:24.796928       1 remote_mediation_client.go:99] Registration with server failed
I0617 18:58:24.796945       1 client_websocket_transport.go:132] Begin to send websocket Close frame.
I0617 18:58:24.797233       1 client_websocket_transport.go:207] stop listening for message because of requested
E0617 18:58:24.797377       1 tap_service.go:37] Probe Cloud Native::Kubernetes-Turbonomic registration failed.
E0617 18:58:24.797393       1 tap_service.go:39] Notified to close TAP service.
I0617 18:58:24.797408       1 tap_service.go:81] Begin to stop TAP service.
I0617 18:58:24.797424       1 mediation_container.go:86] [CloseMediationContainer] Closing mediation container .....
panic: close of closed channel

goroutine 1 [running]:
github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*remoteMediationClient).Stop(0xc00003a320)
	/Users/meng/go/src/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go:164 +0x2f
github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.CloseMediationContainer()
	/Users/meng/go/src/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_container.go:88 +0x71
github.com/turbonomic/turbo-go-sdk/pkg/service.(*TAPService).ConnectToTurbo(0xc0002ec200)
	/Users/meng/go/src/github.com/turbonomic/turbo-go-sdk/pkg/service/tap_service.go:82 +0x164
github.com/turbonomic/kubeturbo/cmd/kubeturbo/app.(*VMTServer).Run(0xc0000e2c00)
	/Users/meng/go/src/github.com/turbonomic/kubeturbo/cmd/kubeturbo/app/kubeturbo_builder.go:306 +0x7e6
main.main()
	/Users/meng/go/src/github.com/turbonomic/kubeturbo/cmd/kubeturbo/kubeturbo.go:108 +0x201
```
On the server side, there will be the following ongoing errors:
```
topology-processor-5bfdc66fb-svd 2020-06-17 18:59:21,854  WARN [qtp-794034589-31] [PageNotFound]	: No mapping for GET /vmturbo/remoteMediation
topology-processor-5bfdc66fb-svd 2020-06-17 18:59:21,891 ERROR [sdk-server-158] [SdkServerProtocol$ContainerRegistrationEndpoint]	: Unable to deserialize raw data com.vmturbo.communication.MultiByteBufferInputStream@345bb113 received from ContainerRegistrationEndpoint[WebsocketServerTransport[ws://topology-processor:8080/remoteMediation-127]]
topology-processor-5bfdc66fb-svd com.google.protobuf.InvalidProtocolBufferException: Message missing required fields: probes[0].supplyChainDefinitionSet[0].commodityBought[0].key.templateClass, probes[0].supplyChainDefinitionSet[1].templateClass, probes[0].supplyChainDefinitionSet[7].mergedEntityMetaData.matchingMetadata.returnType, probes[0].supplyChainDefinitionSet[7].mergedEntityMetaData.matchingMetadata.externalEntityReturnType, probes[0].entityMetadata[6].entityType, probes[0].actionPolicy[3].entityType
topology-processor-5bfdc66fb-svd 	at com.google.protobuf.UninitializedMessageException.asInvalidProtocolBufferException(UninitializedMessageException.java:79)
topology-processor-5bfdc66fb-svd 	at com.google.protobuf.AbstractParser.checkMessageInitialized(AbstractParser.java:68)
topology-processor-5bfdc66fb-svd 	at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:86)
topology-processor-5bfdc66fb-svd 	at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:91)
topology-processor-5bfdc66fb-svd 	at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:48)
topology-processor-5bfdc66fb-svd 	at com.google.protobuf.GeneratedMessageV3.parseWithIOException(GeneratedMessageV3.java:357)
topology-processor-5bfdc66fb-svd 	at com.vmturbo.platform.sdk.common.MediationMessage$ContainerInfo.parseFrom(MediationMessage.java:14615)
topology-processor-5bfdc66fb-svd 	at 
```

This PR addresses this issue proactively, such that when probe registration fails, the probe does not crash. It will log a proper error message and stay alive without keeping re-registering:

```
I0617 20:58:30.152545       1 client_websocket_transport.go:371] Trying websocket connection to: ws://topology-processor:8080/remoteMediation
I0617 20:58:30.160423       1 client_websocket_transport.go:374] Successfully connected to topology-processor service at: ws://topology-processor:8080/remoteMediation
I0617 20:58:30.160556       1 client_websocket_transport.go:293] Connected to server 10.233.61.25:8080::10.233.90.96:54708
I0617 20:58:30.160574       1 client_websocket_transport.go:294] WebSocket transport layer is ready.
I0617 20:58:30.160642       1 remote_mediation_client.go:93] Start sdk client protocol ........
I0617 20:58:30.160691       1 sdk_client_protocol.go:32] Starting protocol negotiation ....
I0617 20:58:30.171602       1 sdk_client_protocol.go:115] Protocol negotiation result: ACCEPTED. Protocol version "7.22.2" is allowed to interact with server.
I0617 20:58:30.171672       1 sdk_client_protocol.go:41] Starting probe registration ....
I0617 20:58:30.171690       1 sdk_client_protocol.go:163] SdkClientProtocol] Creating Probe Info for Kubernetes-Turbonomic
E0617 20:59:00.171598       1 client_websocket_transport.go:218] [ListenForMessages] error during receive websocket: close 1001 (going away): WebsocketServerTransport[ws://topology-processor:8080/remoteMediation-180] shut down
I0617 20:59:00.173602       1 client_websocket_transport.go:132] Begin to send websocket Close frame.
E0617 20:59:00.174556       1 sdk_client_protocol.go:72] [RegistrationEndpoint]: wait for message from channel timeout(30 seconds)
E0617 20:59:00.174589       1 sdk_client_protocol.go:144] [RegistrationEndpoint] : read Registration response from channel failed: [RegistrationEndpoint]: wait for message from channel timeout(30 seconds)
E0617 20:59:00.174609       1 sdk_client_protocol.go:44] Failure during Registration, cannot receive server messages
E0617 20:59:00.174633       1 remote_mediation_client.go:102] Registration with server failed with status false
E0617 20:59:00.174684       1 tap_service.go:37] Probe Cloud Native::Kubernetes-Turbonomic registration failed.
```
