### PR TITLE
Miscellaneous changes related target turbo with turbo

### DIFF
--- a/pkg/builder/commodity_dto_builder.go
+++ b/pkg/builder/commodity_dto_builder.go
@@ -48,7 +48,7 @@ func (cb *CommodityDTOBuilder) Create() (*proto.CommodityDTO, error) {
 	if cb.err != nil {
 		return nil, cb.err
 	}
-	if err := cb.validate(); err != nil {
+	if err := cb.validateAndConvert(); err != nil {
 		return nil, err
 	}
 	commodityDTO := &proto.CommodityDTO{
@@ -154,7 +154,8 @@ func (cb *CommodityDTOBuilder) UtilizationData(points []float64, lastPointTimest
 	return cb
 }
 
-func (cb *CommodityDTOBuilder) validate() error {
+func (cb *CommodityDTOBuilder) validateAndConvert() error {
+	// Access commodities could have nil used value.
 	if cb.used != nil && *cb.used < 0 {
 		return fmt.Errorf("commodity %v has negative used value", cb.commodityType)
 	}

--- a/pkg/builder/commodity_dto_builder.go
+++ b/pkg/builder/commodity_dto_builder.go
@@ -1,6 +1,14 @@
 package builder
 
-import "github.com/turbonomic/turbo-go-sdk/pkg/proto"
+import (
+	"fmt"
+	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"math"
+)
+
+const (
+	OneHundredPercent = 100.0
+)
 
 type CommodityDTOBuilder struct {
 	commodityType           *proto.CommodityDTO_CommodityType
@@ -20,15 +28,12 @@ type CommodityDTOBuilder struct {
 	isUsedPct               *bool
 	utilizationThresholdPct *float64
 	pricingMetadata         *proto.CommodityDTO_PricingMetadata
-
-	storageLatencyData    *proto.CommodityDTO_StorageLatencyData
-	storageAccessData     *proto.CommodityDTO_StorageAccessData
-	vstoragePartitionData *proto.VStoragePartitionData
-
-	utilizationData *proto.CommodityDTO_UtilizationData
-
-	vMemData *proto.CommodityDTO_VMemData
-	vCpuData *proto.CommodityDTO_VCpuData
+	storageLatencyData      *proto.CommodityDTO_StorageLatencyData
+	storageAccessData       *proto.CommodityDTO_StorageAccessData
+	vstoragePartitionData   *proto.VStoragePartitionData
+	utilizationData         *proto.CommodityDTO_UtilizationData
+	vMemData                *proto.CommodityDTO_VMemData
+	vCpuData                *proto.CommodityDTO_VCpuData
 
 	err error
 }
@@ -42,6 +47,9 @@ func NewCommodityDTOBuilder(commodityType proto.CommodityDTO_CommodityType) *Com
 func (cb *CommodityDTOBuilder) Create() (*proto.CommodityDTO, error) {
 	if cb.err != nil {
 		return nil, cb.err
+	}
+	if err := cb.validate(); err != nil {
+		return nil, err
 	}
 	commodityDTO := &proto.CommodityDTO{
 		CommodityType:   cb.commodityType,
@@ -146,16 +154,35 @@ func (cb *CommodityDTOBuilder) UtilizationData(points []float64, lastPointTimest
 	return cb
 }
 
-func buildPropertyMap(propMap map[string][]string) []*proto.CommodityDTO_PropertiesList {
-	if propMap == nil {
-		return nil
+func (cb *CommodityDTOBuilder) validate() error {
+	if cb.used != nil && *cb.used < 0 {
+		return fmt.Errorf("commodity %v has negative used value", cb.commodityType)
 	}
-	propList := []*proto.CommodityDTO_PropertiesList{}
+	switch *cb.commodityType {
+	case proto.CommodityDTO_THREADS, proto.CommodityDTO_CONNECTION:
+		if cb.capacity == nil {
+			return fmt.Errorf("commodity %v has nil capacity", cb.commodityType)
+		}
+	case proto.CommodityDTO_REMAINING_GC_CAPACITY:
+		// The garbage collection time (gcTime) is in percentage, and is transformed to a commodity
+		// with a capacity 100 [percent] and a used value that is 100 - gcTime.
+		if cb.used == nil {
+			return fmt.Errorf("commodity %v has nil used value", cb.commodityType)
+		}
+		used := math.Max(0.0, OneHundredPercent-*cb.used)
+		cb.Used(used).Capacity(OneHundredPercent)
+	case proto.CommodityDTO_DB_CACHE_HIT_RATE:
+		cb.Capacity(OneHundredPercent)
+	}
+	return nil
+}
+
+func buildPropertyMap(propMap map[string][]string) (propList []*proto.CommodityDTO_PropertiesList) {
 	for name, values := range propMap {
 		propList = append(propList, &proto.CommodityDTO_PropertiesList{
 			Name:   &name,
 			Values: values,
 		})
 	}
-	return propList
+	return
 }

--- a/pkg/builder/commodity_dto_builder_test.go
+++ b/pkg/builder/commodity_dto_builder_test.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	mathrand "math/rand"
 	"reflect"
 	"testing"
@@ -311,6 +312,29 @@ func TestCommodityDTOBuilder_UtilizationData(t *testing.T) {
 			t.Errorf("\nExpected %+v, \ngot      %+v", expectedBuilder, builder)
 		}
 	}
+}
+
+func TestCommodityDTOBuilder_RemainingGCCapacity(t *testing.T) {
+	builder := NewCommodityDTOBuilder(proto.CommodityDTO_REMAINING_GC_CAPACITY).Used(10)
+	commodity, err := builder.Create()
+	assert.NoError(t, err)
+	assert.NotNil(t, commodity)
+	assert.Equal(t, commodity.GetCapacity(), 100.0)
+	assert.Equal(t, commodity.GetUsed(), 90.0)
+}
+
+func TestCommodityDTOBuilder_NoCapacity(t *testing.T) {
+	builder := NewCommodityDTOBuilder(proto.CommodityDTO_CONNECTION).Used(10)
+	commodity, err := builder.Create()
+	assert.Nil(t, commodity)
+	assert.EqualError(t, err, "commodity CONNECTION has nil capacity")
+}
+
+func TestCommodityDTOBuilder_NegativeUsed(t *testing.T) {
+	builder := randomBaseCommodityDTOBuilder().Used(-1).Capacity(200)
+	commodity, err := builder.Create()
+	assert.Nil(t, commodity)
+	assert.EqualError(t, err, fmt.Errorf("commodity %v has negative used value", builder.commodityType).Error())
 }
 
 func randomBaseCommodityDTOBuilder() *CommodityDTOBuilder {

--- a/pkg/builder/merged_entity_meta_data_builder.go
+++ b/pkg/builder/merged_entity_meta_data_builder.go
@@ -1,23 +1,10 @@
 package builder
 
 import (
-	"fmt"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
 type ReturnType string
-
-const (
-	MergedEntityMetadata_STRING      ReturnType = "String"
-	MergedEntityMetadata_LIST_STRING ReturnType = "List"
-)
-
-var (
-	returnTypeMapping = map[ReturnType]proto.MergedEntityMetadata_ReturnType{
-		MergedEntityMetadata_STRING:      proto.MergedEntityMetadata_STRING,
-		MergedEntityMetadata_LIST_STRING: proto.MergedEntityMetadata_LIST_STRING,
-	}
-)
 
 // ============================ MergedEntityMetadata_MatchingMetadata ==============================
 // matchingData is structure to hold all the fields of the MatchingData proto message.
@@ -104,26 +91,7 @@ func newMatchingMetadataBuilder() *matchingMetadataBuilder {
 }
 
 func (builder *matchingMetadataBuilder) build() (*proto.MergedEntityMetadata_MatchingMetadata, error) {
-	// validate internal property return type
-	if builder.internalReturnType == "" {
-		return nil, fmt.Errorf("internal entity metadata return type not set")
-	}
-	internalReturnType, exists := returnTypeMapping[builder.internalReturnType]
-	if !exists {
-		return nil, fmt.Errorf("unknown internal entity metadata return type")
-	}
-	// validate external property return type
-	if builder.externalReturnType == "" {
-		return nil, fmt.Errorf("external entity metadata return type not set")
-	}
-	externalReturnType, exists := returnTypeMapping[builder.externalReturnType]
-	if !exists {
-		return nil, fmt.Errorf("unknown external entity metadata return type")
-	}
-	matchingMetadata := &proto.MergedEntityMetadata_MatchingMetadata{
-		ReturnType:               &internalReturnType,
-		ExternalEntityReturnType: &externalReturnType,
-	}
+	matchingMetadata := &proto.MergedEntityMetadata_MatchingMetadata{}
 	// create internal property matching data
 	for _, internalData := range builder.internalMatchingData {
 		matchingMetadata.MatchingData =

--- a/pkg/builder/merged_entity_meta_data_builder_test.go
+++ b/pkg/builder/merged_entity_meta_data_builder_test.go
@@ -2,7 +2,6 @@ package builder
 
 import (
 	"github.com/stretchr/testify/assert"
-	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 	"testing"
 )
 
@@ -94,8 +93,6 @@ func TestMergedEntityMetadataBuilderInternalMatching(t *testing.T) {
 	props = append(props, prop1)
 	props = append(props, prop2)
 
-	builder.InternalMatchingType(MergedEntityMetadata_STRING)
-	builder.ExternalMatchingType(MergedEntityMetadata_STRING)
 	builder.InternalMatchingProperty(prop2)
 	builder.InternalMatchingProperty(prop1)
 
@@ -103,7 +100,6 @@ func TestMergedEntityMetadataBuilderInternalMatching(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, proto.MergedEntityMetadata_STRING, md.GetMatchingMetadata().GetReturnType())
 	assert.Equal(t, 2, len(md.GetMatchingMetadata().GetMatchingData()))
 	assert.NotNil(t, md.GetMatchingMetadata().GetMatchingData())
 
@@ -122,15 +118,12 @@ func TestMergedEntityMetadataBuilderExternalMatching(t *testing.T) {
 
 	prop1 := "IP"
 
-	builder.InternalMatchingType(MergedEntityMetadata_STRING)
-	builder.ExternalMatchingType(MergedEntityMetadata_STRING)
 	builder.ExternalMatchingPropertyWithDelimiter(prop1, ",")
 
 	md, err := builder.Build()
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, proto.MergedEntityMetadata_STRING, md.GetMatchingMetadata().GetExternalEntityReturnType())
 	assert.Equal(t, 1, len(md.GetMatchingMetadata().GetExternalEntityMatchingProperty()))
 	assert.NotNil(t, md.GetMatchingMetadata().GetExternalEntityMatchingProperty())
 

--- a/pkg/dataingestionframework/data/dif_conversion.go
+++ b/pkg/dataingestionframework/data/dif_conversion.go
@@ -23,17 +23,17 @@ const (
 )
 
 var DIFMetricType = map[proto.CommodityDTO_CommodityType]string{
-	proto.CommodityDTO_RESPONSE_TIME:     "responseTime",
-	proto.CommodityDTO_TRANSACTION:       "transaction",
-	proto.CommodityDTO_VCPU:              "cpu",
-	proto.CommodityDTO_VMEM:              "memory",
-	proto.CommodityDTO_THREADS:           "threads",
-	proto.CommodityDTO_HEAP:              "heap",
-	proto.CommodityDTO_COLLECTION_TIME:   "collectionTime",
-	proto.CommodityDTO_DB_MEM:            "dbMem",
-	proto.CommodityDTO_DB_CACHE_HIT_RATE: "dbCacheHitRate",
-	proto.CommodityDTO_CONNECTION:        "connection",
-	proto.CommodityDTO_KPI:               "kpi",
+	proto.CommodityDTO_RESPONSE_TIME:         "responseTime",
+	proto.CommodityDTO_TRANSACTION:           "transaction",
+	proto.CommodityDTO_VCPU:                  "cpu",
+	proto.CommodityDTO_VMEM:                  "memory",
+	proto.CommodityDTO_THREADS:               "threads",
+	proto.CommodityDTO_HEAP:                  "heap",
+	proto.CommodityDTO_REMAINING_GC_CAPACITY: "remainingGCCapacity",
+	proto.CommodityDTO_DB_MEM:                "dbMem",
+	proto.CommodityDTO_DB_CACHE_HIT_RATE:     "dbCacheHitRate",
+	proto.CommodityDTO_CONNECTION:            "connection",
+	proto.CommodityDTO_KPI:                   "kpi",
 }
 
 var validDIFEntities = []interface{}{

--- a/pkg/supplychain/supply_chain_builder.go
+++ b/pkg/supplychain/supply_chain_builder.go
@@ -2,6 +2,7 @@ package supplychain
 
 import (
 	"fmt"
+	set "github.com/deckarep/golang-set"
 
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
@@ -20,15 +21,71 @@ func (scb *SupplyChainBuilder) Create() ([]*proto.TemplateDTO, error) {
 	if scb.err != nil {
 		return nil, scb.err
 	}
-
+	if err := scb.validateChargedByBoughtRelationships(); err != nil {
+		return nil, err
+	}
+	if err := scb.validateChargedBySoldRelationships(); err != nil {
+		return nil, err
+	}
 	return scb.supplyChainNodes, nil
+}
+
+func (scb *SupplyChainBuilder) validateChargedBySoldRelationships() error {
+	for _, node := range scb.supplyChainNodes {
+		commoditiesSold := getAllCommoditiesSold(node)
+		for _, commodity := range node.GetCommoditySold() {
+			for _, chargedBySold := range commodity.GetChargedBySold() {
+				if !commoditiesSold.Contains(chargedBySold) {
+					return fmt.Errorf("commodity %v of entity template %s is charged by commodity"+
+						" %s which is not declared to be sold by the entity",
+						commodity.GetCommodityType(), node.GetTemplateClass(), chargedBySold)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (scb *SupplyChainBuilder) validateChargedByBoughtRelationships() error {
+	for _, node := range scb.supplyChainNodes {
+		commoditiesBought := getAllCommoditiesBought(node)
+		for _, commodity := range node.GetCommoditySold() {
+			for _, chargedBy := range commodity.GetChargedBy() {
+				if !commoditiesBought.Contains(chargedBy) {
+					return fmt.Errorf("commodity %v of entity template %s is charged by commodity"+
+						" %s which is not declared to be bought by the entity",
+						commodity.GetCommodityType(), node.GetTemplateClass(), chargedBy)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func getAllCommoditiesBought(node *proto.TemplateDTO) set.Set {
+	commoditiesBought := set.NewSet()
+	for _, commBoughtProviderMap := range node.GetCommodityBought() {
+		for _, commBought := range commBoughtProviderMap.GetValue() {
+			commoditiesBought.Add(commBought.GetCommodityType())
+		}
+	}
+	// Note: there is no need to check buyer reference from external link which is deprecated.
+	return commoditiesBought
+}
+
+func getAllCommoditiesSold(node *proto.TemplateDTO) set.Set {
+	commoditiesSold := set.NewSet()
+	for _, commSold := range node.GetCommoditySold() {
+		commoditiesSold.Add(commSold.GetCommodityType())
+	}
+	return commoditiesSold
 }
 
 // To build a supply chain, must specify the top supply chain node first.
 // Here it initializes supplyChainNodes.
 func (scb *SupplyChainBuilder) Top(topNode *proto.TemplateDTO) *SupplyChainBuilder {
 	if topNode == nil {
-		scb.err = fmt.Errorf("topNode cannot be nil.")
+		scb.err = fmt.Errorf("top node cannot be nil")
 		return scb
 	}
 	scb.supplyChainNodes = []*proto.TemplateDTO{}
@@ -43,7 +100,7 @@ func (scb *SupplyChainBuilder) Entity(node *proto.TemplateDTO) *SupplyChainBuild
 		return scb
 	}
 	if scb.supplyChainNodes == nil || len(scb.supplyChainNodes) == 0 {
-		scb.err = fmt.Errorf("Must set top supply chain node first.")
+		scb.err = fmt.Errorf("must set top supply chain node first")
 		return scb
 	}
 


### PR DESCRIPTION
This PR addresses the following issues:

* Remove the internal and external return types from merged entity metadata builder due to protocol changes
* Add conversion and validation for certain types of commodities when creating the DTOs:
  * For `THREADS` and `CONNECTION`, requires capacity to be set
  * For `REMAINING_GC_CAPACITY`, set the used value to be 100-used, and set the capacity to be 100
  * For `DB_CACHE_HIT_RATE`, set the capacity to be 100
  * Return error when used value is negative
* Validate the `chargedBy` relationship when creating supply chain nodes
