### PR TITLE
Add default capacity to Application commodity

### DIFF
--- a/pkg/builder/commodity_dto_builder.go
+++ b/pkg/builder/commodity_dto_builder.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	OneHundredPercent = 100.0
+	OneHundredPercent           = 100.0
+	AppCommodityDefaultCapacity = 100000.0
 )
 
 type CommodityDTOBuilder struct {
@@ -178,6 +179,8 @@ func (cb *CommodityDTOBuilder) validateAndConvert() error {
 		cb.Used(used).Capacity(OneHundredPercent)
 	case proto.CommodityDTO_DB_CACHE_HIT_RATE:
 		cb.Capacity(OneHundredPercent)
+	case proto.CommodityDTO_APPLICATION:
+		cb.Capacity(AppCommodityDefaultCapacity)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds a default capacity to the Application commodity being created by both `kubeturbo` and `DIF` probe. 

For other access commodities such as `Cluster` and `VMPMAccess` commodities, `kubeturbo` already sets default capacities for them. `DIF` probe does not create other access commodities.