### PR TITLE
Gracefully shutdown mediation client when registration fails

### DIFF
--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -114,11 +114,7 @@ func (wsTransport *ClientWebSocketTransport) GetConnectionId() string {
 
 // Close the WebSocket Transport point: this is called by upper module (remoteMediationClient)
 func (wsTransport *ClientWebSocketTransport) CloseTransportPoint() {
-	glog.V(4).Infof("[CloseTransportPoint] closing transport endpoint and listener routine")
 	wsTransport.closeRequested = true
-	// close listener
-	wsTransport.stopListenForMessages()
-	wsTransport.closeAndResetWebSocket()
 }
 
 // Close current WebSocket connection and set it to nil.
@@ -171,7 +167,6 @@ func (wsTransport *ClientWebSocketTransport) startPing() {
 func (wsTransport *ClientWebSocketTransport) stopListenForMessages() {
 	if wsTransport.stopListenerCh != nil {
 		glog.V(4).Infof("[StopListenForMessages] closing stopListenerCh %+v", wsTransport.stopListenerCh)
-		wsTransport.stopListenerCh <- true
 		close(wsTransport.stopListenerCh)
 		glog.V(4).Infof("[StopListenForMessages] closed stopListenerCh %+v", wsTransport.stopListenerCh)
 	}

--- a/pkg/mediationcontainer/mediation_container.go
+++ b/pkg/mediationcontainer/mediation_container.go
@@ -62,7 +62,7 @@ func CreateMediationContainer(containerConfig *MediationContainerConfig) *mediat
 }
 
 // Start the RemoteMediationClient
-func InitMediationContainer(probeRegisteredMsg chan bool) {
+func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo chan struct{}) {
 	theContainer := singletonMediationContainer()
 	glog.Infof("Initializing mediation container .....")
 	// Assert that the probes are registered before starting the handshake
@@ -74,7 +74,7 @@ func InitMediationContainer(probeRegisteredMsg chan bool) {
 	glog.V(2).Infof("Registering %d probes", len(theContainer.allProbes))
 
 	remoteMediationClient := theContainer.theRemoteMediationClient
-	remoteMediationClient.Init(probeRegisteredMsg)
+	remoteMediationClient.Init(probeRegisteredMsg, disconnectFromTurbo)
 }
 
 func GetMediationService() string {


### PR DESCRIPTION
In #101 , we modified the logic to allow probe to continue instead of exit with panic when registration fails (e.g., due to protocol incompatibility with server). Once a probe reaches this state, it will not retry registration anymore.

However, in some circumstances, we do want to retry registration when it fails. For example, when server is being upgraded (there is no protocol incompatibility issue), not all services are ready at the same time, and as a result, the probe registration may fail temporarily. We want the probe to retry registration until all services are ready, at which time the registration will succeed. If we do not retry, user has to manually restart the probe. It is rare to have protocol incompatibility between `kubeturbo` and the server, but server upgrade is more common. So overall,  it is still desirable to let `kubeturbo` restart when registration fails.

This PR addresses the issue of ungraceful shutdown of the probe, where the probe panics with `close of closed channel` error being logged:
```
E0617 18:58:24.796892       1 sdk_client_protocol.go:44] Failure during Registration, cannot receive server messages
E0617 18:58:24.796928       1 remote_mediation_client.go:99] Registration with server failed
I0617 18:58:24.796945       1 client_websocket_transport.go:132] Begin to send websocket Close frame.
I0617 18:58:24.797233       1 client_websocket_transport.go:207] stop listening for message because of requested
E0617 18:58:24.797377       1 tap_service.go:37] Probe Cloud Native::Kubernetes-Turbonomic registration failed.
E0617 18:58:24.797393       1 tap_service.go:39] Notified to close TAP service.
I0617 18:58:24.797408       1 tap_service.go:81] Begin to stop TAP service.
I0617 18:58:24.797424       1 mediation_container.go:86] [CloseMediationContainer] Closing mediation container .....
panic: close of closed channel

goroutine 1 [running]:
github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*remoteMediationClient).Stop(0xc00003a320)
	/Users/meng/go/src/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/remote_mediation_client.go:164 +0x2f
github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.CloseMediationContainer()
	/Users/meng/go/src/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/mediation_container.go:88 +0x71
github.com/turbonomic/turbo-go-sdk/pkg/service.(*TAPService).ConnectToTurbo(0xc0002ec200)
	/Users/meng/go/src/github.com/turbonomic/turbo-go-sdk/pkg/service/tap_service.go:82 +0x164
github.com/turbonomic/kubeturbo/cmd/kubeturbo/app.(*VMTServer).Run(0xc0000e2c00)
	/Users/meng/go/src/github.com/turbonomic/kubeturbo/cmd/kubeturbo/app/kubeturbo_builder.go:306 +0x7e6
main.main()
	/Users/meng/go/src/github.com/turbonomic/kubeturbo/cmd/kubeturbo/kubeturbo.go:108 +0x201
```

Minimal changes are attempted to mitigate the risks:

* In `remoteMediationClient.Stop`, do not close `stopMsgHandlerCh` and `stopListenerCh`. These cause the panic with `close of closed channel`. There is no need to close these channels in this function, as the probe will exit anyway after this function is called: `remoteMediationClient.Stop` -> close `closeWatcherCh` and `stopMediationClientCh` channel -> Stop the monitor go routine -> Exit `remoteMediationClient.Init`.
* Pass the `disconnectFromTurbo` channel to the `mediationcontainer.InitMediationContainer` and `remoteMediationClient.Init` function such that when probe registration fails,  `disconnectFromTurbo` channel will be closed, and `tapService.ConnectToTurbo` will return and allow probe to exit cleanly.

Tests:

When probe registration fails for whatever reason, the following messages are logged and `kubeturbo` will exit gracefully, and then will be restarted:
```
I0706 15:59:11.386467       1 client_protobuf_endpoint.go:36] Created Protobuf Endpoint RegistrationEndpoint
I0706 15:59:11.386492       1 client_protobuf_endpoint.go:144] [RegistrationEndpoint][[waitForSingleServerMessage] : waiting for server response
I0706 15:59:11.386529       1 client_protobuf_endpoint.go:78] [RegistrationEndpoint] : Sending protobuf message
I0706 15:59:11.387502       1 client_websocket_transport.go:267] Successfully sent message on client transport
I0706 15:59:41.383412       1 client_websocket_transport.go:200] Received websocket message of type -1 and size 0
E0706 15:59:41.383477       1 client_websocket_transport.go:214] [ListenForMessages] error during receive websocket: close 1001 (going away): WebsocketServerTransport[ws://topology-processor:8080/remoteMediation-1512] shut down
I0706 15:59:41.384700       1 client_websocket_transport.go:129] Begin to send websocket Close frame.
I0706 15:59:41.384882       1 client_websocket_transport.go:170] [StopListenForMessages] closing stopListenerCh 0xc0005341c0
I0706 15:59:41.384923       1 client_websocket_transport.go:172] [StopListenForMessages] closed stopListenerCh 0xc0005341c0
E0706 15:59:41.387772       1 sdk_client_protocol.go:73] [RegistrationEndpoint]: wait for message from channel timeout(30 seconds)
E0706 15:59:41.387819       1 sdk_client_protocol.go:145] [RegistrationEndpoint] : read Registration response from channel failed: [RegistrationEndpoint]: wait for message from channel timeout(30 seconds)
I0706 15:59:41.387840       1 client_protobuf_endpoint.go:67] [RegistrationEndpoint] : closing endpoint and listener routine
E0706 15:59:41.387852       1 sdk_client_protocol.go:45] Failure during Registration, cannot receive server messages
I0706 15:59:41.387887       1 remote_mediation_client.go:99] Sdk client protocol completed with status false
E0706 15:59:41.387901       1 remote_mediation_client.go:101] Registration with server failed with status false
I0706 15:59:41.387916       1 tap_service.go:72] Begin to stop TAP service.
I0706 15:59:41.387932       1 mediation_container.go:86] [CloseMediationContainer] Closing mediation container .....
I0706 15:59:41.387945       1 client_websocket_transport.go:117] [CloseTransportPoint] closing transport endpoint and listener routine
I0706 15:59:41.387957       1 tap_service.go:74] TAP service is stopped.
I0706 15:59:41.387979       1 kubeturbo_builder.go:308] Kubeturbo service is stopped.

```