### PR TITLE
Properly support multiple keys for the same type of commodity

### DIFF
--- a/pkg/dataingestionframework/data/dif_types_test.go
+++ b/pkg/dataingestionframework/data/dif_types_test.go
@@ -1,0 +1,56 @@
+package data
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAddMetricWithNoKey(t *testing.T) {
+	average := float64(300)
+	capacity := float64(500)
+	mType := "responseTime"
+	difEntity := NewDIFEntity("uid", "application")
+	difEntity.AddMetric(mType, AVERAGE, average, "")
+	difEntity.AddMetric(mType, CAPACITY, capacity, "")
+	metricMap := difEntity.Metrics
+	assert.Equal(t, 1, len(metricMap))
+	metrics, _ := metricMap[mType]
+	assert.Equal(t, 1, len(metrics))
+	metric := metrics[0]
+	assert.Equal(t, *metric.Average, average)
+	assert.Equal(t, *metric.Capacity, capacity)
+	assert.Nil(t, metric.Key)
+}
+
+func TestAddMetricWithSameKey(t *testing.T) {
+	average := float64(300)
+	capacity := float64(500)
+	mType := "kpi"
+	key := "key"
+	difEntity := NewDIFEntity("uid", "application")
+	difEntity.AddMetric(mType, AVERAGE, average, key)
+	difEntity.AddMetric(mType, CAPACITY, capacity, key)
+	metricMap := difEntity.Metrics
+	assert.Equal(t, 1, len(metricMap))
+	metrics, _ := metricMap[mType]
+	assert.Equal(t, 1, len(metrics))
+	metric := metrics[0]
+	assert.Equal(t, *metric.Average, average)
+	assert.Equal(t, *metric.Capacity, capacity)
+	assert.EqualValues(t, *metric.Key, key)
+}
+
+func TestAddMetricWithDifferentKey(t *testing.T) {
+	average1 := float64(300)
+	average2 := float64(500)
+	mType := "kpi"
+	key1 := "key1"
+	key2 := "key2"
+	difEntity := NewDIFEntity("uid", "application")
+	difEntity.AddMetric(mType, AVERAGE, average1, key1)
+	difEntity.AddMetric(mType, AVERAGE, average2, key2)
+	metricMap := difEntity.Metrics
+	assert.Equal(t, 1, len(metricMap))
+	metrics, _ := metricMap[mType]
+	assert.Equal(t, 2, len(metrics))
+}

--- a/pkg/dataingestionframework/data/dif_types_test.go
+++ b/pkg/dataingestionframework/data/dif_types_test.go
@@ -53,4 +53,60 @@ func TestAddMetricWithDifferentKey(t *testing.T) {
 	assert.Equal(t, 1, len(metricMap))
 	metrics, _ := metricMap[mType]
 	assert.Equal(t, 2, len(metrics))
+	total := float64(0)
+	for _, metric := range metrics {
+		total += *metric.Average
+	}
+	assert.EqualValues(t, average1+average2, total)
+}
+
+func TestAddMetricWithOverwritingValues(t *testing.T) {
+	average1 := float64(300)
+	average2 := float64(500)
+	average3 := float64(777)
+	capacity3 := float64(10000)
+	mType := "kpi"
+	key1 := "key1"
+	key2 := "key2"
+	key3 := key2
+	difEntity := NewDIFEntity("uid", "application")
+	difEntity.AddMetric(mType, AVERAGE, average1, key1)
+	difEntity.AddMetric(mType, AVERAGE, average2, key2)
+	// average3 should overwrite average2 for key2
+	difEntity.AddMetric(mType, AVERAGE, average3, key3)
+	difEntity.AddMetric(mType, CAPACITY, capacity3, key3)
+	metricMap := difEntity.Metrics
+	assert.Equal(t, 1, len(metricMap))
+	metrics, _ := metricMap[mType]
+	assert.Equal(t, 2, len(metrics))
+	assert.EqualValues(t, average1, *metrics[0].Average)
+	assert.Equal(t, key1, *metrics[0].Key)
+	assert.EqualValues(t, average3, *metrics[1].Average)
+	assert.EqualValues(t, capacity3, *metrics[1].Capacity)
+	assert.Equal(t, key2, *metrics[1].Key)
+}
+
+func TestAddMetricWithKeyAndNoKey(t *testing.T) {
+	// This should be an edge case
+	average1 := float64(300)
+	average2 := float64(500)
+	average3 := float64(777)
+	capacity3 := float64(10000)
+	mType := "kpi"
+	key1 := "key1"
+	key2 := ""
+	difEntity := NewDIFEntity("uid", "application")
+	difEntity.AddMetric(mType, AVERAGE, average1, key1)
+	difEntity.AddMetric(mType, AVERAGE, average2, key2)
+	difEntity.AddMetric(mType, AVERAGE, average3, key2)
+	difEntity.AddMetric(mType, CAPACITY, capacity3, key2)
+	metricMap := difEntity.Metrics
+	assert.Equal(t, 1, len(metricMap))
+	metrics, _ := metricMap[mType]
+	assert.Equal(t, 2, len(metrics))
+	assert.EqualValues(t, average1, *metrics[0].Average)
+	assert.Equal(t, key1, *metrics[0].Key)
+	assert.EqualValues(t, average3, *metrics[1].Average)
+	assert.EqualValues(t, capacity3, *metrics[1].Capacity)
+	assert.Nil(t, metrics[1].Key)
 }


### PR DESCRIPTION
https://vmturbo.atlassian.net/browse/OM-64661

Currently in `DIFEntity`, the `Metrics` is a map where the key is the metric type, and the value is an array of metric definitions:

```
type DIFEntity struct {
	UID                 string                     `json:"uniqueId"`
	Type                string                     `json:"type"`
	Name                string                     `json:"name"`
	HostedOn            *DIFHostedOn               `json:"hostedOn"`
	MatchingIdentifiers *DIFMatchingIdentifiers    `json:"matchIdentifiers"`
	PartOf              []*DIFPartOf               `json:"partOf"`
	Metrics             map[string][]*DIFMetricVal `json:"metrics"`
	namespace           string
	partOfSet           set.Set
	hostTypeSet         set.Set
}
```
We did not properly specify the use case for the array of metric definitions. After discussion with @pallavidn, we clarified that the only need for an array of metrics of the same type would be for those metrics with different keys.

This fix modifies the `AddMetric` SDK function to allow adding metrics of the same type but different keys for the same entity.

As an example, the metric created from using this SDK function may look like this when marshalled into JSON:

```JSON
kpi: [
    {
        average: 123,
        capacity: 1000,
        key: "total_messages_in_queue"
    },
    {
        average: 104.44444444444444,
        capacity: 1000,
        key: "total_waiting_time_in_queue"
    }
],
```