### PR TITLE
Fix channel close at exit

### DIFF
--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -121,7 +121,7 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 				// handle WebSocket creation errors
 				if err != nil { //transport.ws == nil {
 					glog.Errorf("[Reconnect] Initialization of remote mediation client failed: %v", err)
-					remoteMediationClient.Stop()
+					close(disconnectFromTurbo)
 					break
 				}
 				// sdk registration protocol
@@ -130,7 +130,7 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 				endProtocol := <-transportReady
 				if !endProtocol {
 					glog.Errorf("[Reconnect] Registration with server failed")
-					remoteMediationClient.Stop()
+					close(disconnectFromTurbo)
 					break
 				}
 				// start listener for server messages
@@ -155,7 +155,6 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 	select {
 	case <-remoteMediationClient.stopMediationClientCh:
 		glog.V(4).Infof("[Init] Exit routine *************")
-		close(disconnectFromTurbo)
 		return
 	}
 }


### PR DESCRIPTION
We consistently get a panic at kubeturbo exit:
```
I1123 08:50:02.533964       1 kubeturbo_builder.go:363] Kubeturbo service is stopped.
I1123 08:50:02.534010       1 remote_mediation_client.go:157] [Init] Exit routine *************
panic: close of closed channel

goroutine 681 [running]:
github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*remoteMediationClient).Init(0xc00030cf60, 0xc00020fb90, 0xc0005a7b60)
	/Users/irfanurrehman/pkg/mod/github.com/turbonomic/turbo-go-sdk@v0.0.0-20201030102636-d9a5135b441d/pkg/mediationcontainer/remote_mediation_client.go:158 +0x442
github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.InitMediationContainer(0xc00020fb90, 0xc0005a7b60)
	/Users/irfanurrehman/pkg/mod/github.com/turbonomic/turbo-go-sdk@v0.0.0-20201030102636-d9a5135b441d/pkg/mediationcontainer/mediation_container.go:77 +0x10f
created by github.com/turbonomic/turbo-go-sdk/pkg/service.(*TAPService).ConnectToTurbo
	/Users/irfanurrehman/pkg/mod/github.com/turbonomic/turbo-go-sdk@v0.0.0-20201030102636-d9a5135b441d/pkg/service/tap_service.go:66 +0xed
```
This prevents from exit handler function to compelete cleanup as needed by the scc change introduced in https://github.com/turbonomic/kubeturbo/pull/498

I am not completely sure, but I think this was introduced by 
https://github.com/turbonomic/turbo-go-sdk/commit/ba8fc3fb6955ba83e13d29996f975c49738f1c24

The shutdown (for all reasons, eg. websocket error or exit handler or Cntrl+C) is triggered by closing [disconnectFromTurbo](https://github.com/turbonomic/turbo-go-sdk/blob/master/pkg/service/tap_service.go#L20), which triggers the call to [CloseMediationContainer()](https://github.com/turbonomic/turbo-go-sdk/blob/master/pkg/service/tap_service.go#L73) and eventually closes [stopMediationClientCh](https://github.com/turbonomic/turbo-go-sdk/blob/master/pkg/mediationcontainer/remote_mediation_client.go#L174). There is no point in trying to close the `disconnectFromTurbo` again.