### PR TITLE
Escape the special char

### DIFF
--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -136,7 +136,6 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 		BasicAuthentication(url.QueryEscape(commConfig.OpsManagerUsername), url.QueryEscape(commConfig.OpsManagerPassword)).
 		SetProxy(commConfig.ServerMeta.Proxy).
 		Create()
-	glog.V(4).Infof("The Turbo API client config authentication is: %s, %s", commConfig.OpsManagerUsername, commConfig.OpsManagerPassword)
 	glog.V(4).Infof("The Turbo API client config is create successfully: %v", config)
 	builder.tapService.turboClient, err = client.NewTurboClient(config)
 	if err != nil {

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -133,7 +133,7 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 		return builder
 	}
 	config := client.NewConfigBuilder(serverAddress).
-		BasicAuthentication(commConfig.OpsManagerUsername, commConfig.OpsManagerPassword).
+		BasicAuthentication(url.QueryEscape(commConfig.OpsManagerUsername), url.QueryEscape(commConfig.OpsManagerPassword)).
 		SetProxy(commConfig.ServerMeta.Proxy).
 		Create()
 	glog.V(4).Infof("The Turbo API client config authentication is: %s, %s", commConfig.OpsManagerUsername, commConfig.OpsManagerPassword)


### PR DESCRIPTION
Background:
We have customer reported the following:
Looks like we got past the 401 error by changing the password to something less complex. The password was “uZ3sE161G$0&E4d5”, we changed it to “Password123” and it worked.

That password was able to be used to login to the UI just fine. Are you guys aware that the UI accepts passwords that the API doesn’t? Is this a password encapsulation issue? Seems like a bug to me.

Fix:
Escape the special Char with url.QueryEscape

Side-fix:
Removed sensitive logging