### PR TITLE
[OM-85109]: Go SDK support for secure probe connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.4.1
 	github.com/stretchr/testify v1.3.0
-	github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca
+	github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,12 +7,10 @@ github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9r
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
-github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -21,8 +19,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca h1:kWhxdWkGgeMNZQgZ+FQVFW0FEau2fHwraM7OGFug6Tw=
-github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8 h1:KNqHTUIunOPSHyO8FHgrMq8KMzgXpxHe7nW0dCnkfic=
+github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/pkg/mediationcontainer/mediation_communication_config.go
+++ b/pkg/mediationcontainer/mediation_communication_config.go
@@ -21,9 +21,11 @@ var (
 )
 
 type ServerMeta struct {
-	TurboServer string `json:"turboServer,omitempty"`
-	Version     string `json:"version,omitempty"`
-	Proxy       string `json:"proxy,omitempty"`
+	TurboServer  string `json:"turboServer,omitempty"`
+	Version      string `json:"version,omitempty"`
+	Proxy        string `json:"proxy,omitempty"`
+	ClientId     string `json:"clientId,omitempty"`
+	ClientSecret string `json:"clientSecret,omitempty"`
 }
 
 func (meta *ServerMeta) ValidateServerMeta() error {

--- a/pkg/mediationcontainer/mediation_container.go
+++ b/pkg/mediationcontainer/mediation_container.go
@@ -62,7 +62,7 @@ func CreateMediationContainer(containerConfig *MediationContainerConfig) *mediat
 }
 
 // Start the RemoteMediationClient
-func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo chan struct{}) {
+func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo chan struct{}, jwtToken string) {
 	theContainer := singletonMediationContainer()
 	glog.Infof("Initializing mediation container .....")
 	// Assert that the probes are registered before starting the handshake
@@ -74,7 +74,7 @@ func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo ch
 	glog.V(2).Infof("Registering %d probes", len(theContainer.allProbes))
 
 	remoteMediationClient := theContainer.theRemoteMediationClient
-	remoteMediationClient.Init(probeRegisteredMsg, disconnectFromTurbo)
+	remoteMediationClient.Init(probeRegisteredMsg, disconnectFromTurbo, jwtToken)
 }
 
 func GetMediationService() string {

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -55,7 +55,7 @@ func CreateRemoteMediationClient(allProbes map[string]*ProbeProperties,
 
 // Establish connection with the Turbo server -  Blocks till WebSocket connection is open
 // Complete the probe registration protocol with the server and then wait for server messages
-func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh chan bool, disconnectFromTurbo chan struct{}) {
+func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh chan bool, disconnectFromTurbo chan struct{}, jwtToken string) {
 	// TODO: Assert that the probes are registered before starting the handshake ??
 
 	//// --------- Create WebSocket Transport
@@ -76,7 +76,7 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 	transport := CreateClientWebSocketTransport(connConfig) //, transportClosedNotificationCh)
 	remoteMediationClient.closeWatcherCh = make(chan bool, 1)
 
-	err = transport.Connect() // TODO: blocks till websocket connection is open or until transport is closed
+	err = transport.Connect(jwtToken) // TODO: blocks till websocket connection is open or until transport is closed
 
 	// handle WebSocket creation errors
 	if err != nil { //transport.ws == nil {
@@ -117,7 +117,7 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 				// stop server messages listener
 				remoteMediationClient.stopMessageHandler()
 				// Reconnect
-				err := transport.Connect()
+				err := transport.Connect(jwtToken)
 				// handle WebSocket creation errors
 				if err != nil { //transport.ws == nil {
 					glog.Errorf("[Reconnect] Initialization of remote mediation client failed: %v", err)

--- a/pkg/mediationcontainer/transport_endpoint.go
+++ b/pkg/mediationcontainer/transport_endpoint.go
@@ -3,7 +3,7 @@ package mediationcontainer
 // Transport endpoint that sends and receives raw message bytes
 type ITransport interface {
 	// Open
-	Connect() error
+	Connect(jwtToken string) error
 	GetConnectionId() string
 	GetService() string
 	// Send

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -43,7 +43,6 @@ func (tapService *TAPService) getJwtToken(hydraToken string) (string, error) {
 	return jwtToken, nil
 }
 
-
 func (tapService *TAPService) addTarget(isRegistered chan bool) {
 	targetInfos := tapService.GetProbeTargets()
 	if len(targetInfos) <= 0 {

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -2,13 +2,12 @@ package service
 
 import (
 	"fmt"
-	"github.com/turbonomic/turbo-api/pkg/api"
-	"net/url"
-
 	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-api/pkg/api"
 	"github.com/turbonomic/turbo-api/pkg/client"
 	"github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer"
 	"github.com/turbonomic/turbo-go-sdk/pkg/probe"
+	"net/url"
 )
 
 // Turbonomic Automation Service that will discover the environment for the Turbo server
@@ -27,6 +26,23 @@ func (tapService *TAPService) DisconnectFromTurbo() {
 	close(tapService.disconnectFromTurbo)
 	glog.V(4).Infof("[DisconnectFromTurbo] End *********")
 }
+
+func (tapService *TAPService) getHydraToken() (string, error) {
+	hydraToken, err := tapService.turboClient.GetHydraAccessToken()
+	if err != nil {
+		return "", err
+	}
+	return hydraToken, nil
+}
+
+func (tapService *TAPService) getJwtToken(hydraToken string) (string, error) {
+	jwtToken, err := tapService.turboClient.GetJwtToken(hydraToken)
+	if err != nil {
+		return "", err
+	}
+	return jwtToken, nil
+}
+
 
 func (tapService *TAPService) addTarget(isRegistered chan bool) {
 	targetInfos := tapService.GetProbeTargets()
@@ -55,8 +71,6 @@ func (tapService *TAPService) addTarget(isRegistered chan bool) {
 }
 
 func (tapService *TAPService) ConnectToTurbo() {
-	glog.V(4).Infof("[ConnectToTurbo] Enter ******* ")
-
 	if tapService.turboClient == nil {
 		glog.V(1).Infof("TAP service cannot be started - cannot create target")
 		return
@@ -65,9 +79,19 @@ func (tapService *TAPService) ConnectToTurbo() {
 	tapService.disconnectFromTurbo = make(chan struct{})
 	isRegistered := make(chan bool, 1)
 	defer close(isRegistered)
-
+	// Get the credential from the secret
+	hydraToken, err := tapService.getHydraToken()
+	if err != nil {
+		glog.V(1).Infof("Failed to get Hydra token")
+		return
+	}
+	jwtToken, err := tapService.getJwtToken(hydraToken)
+	if err != nil {
+		glog.V(1).Infof("Failed to get JWT token")
+		return
+	}
 	// start a separate go routine to connect to the Turbo server
-	go mediationcontainer.InitMediationContainer(isRegistered, tapService.disconnectFromTurbo)
+	go mediationcontainer.InitMediationContainer(isRegistered, tapService.disconnectFromTurbo, jwtToken)
 	go tapService.addTarget(isRegistered)
 
 	// Once connected the mediation container will keep running till a disconnect message is sent to the tap service
@@ -135,6 +159,7 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 	config := client.NewConfigBuilder(serverAddress).
 		BasicAuthentication(url.QueryEscape(commConfig.OpsManagerUsername), url.QueryEscape(commConfig.OpsManagerPassword)).
 		SetProxy(commConfig.ServerMeta.Proxy).
+		SetClientId(commConfig.ServerMeta.ClientId).SetClientSecret(commConfig.ServerMeta.ClientSecret).
 		Create()
 	glog.V(4).Infof("The Turbo API client config is create successfully: %v", config)
 	builder.tapService.turboClient, err = client.NewTurboClient(config)

--- a/vendor/github.com/turbonomic/turbo-api/pkg/api/resource_type.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/api/resource_type.go
@@ -8,4 +8,6 @@ const (
 	Resource_Type_Target          ResourceType = "target"
 	Resource_Type_Probe           ResourceType = "probe"
 	Resource_Type_External_Target ResourceType = "externaltargets"
+	Resource_Type_hydra_token     ResourceType = "token"
+	Resource_Type_auth_token      ResourceType = "exchange"
 )

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
@@ -1,10 +1,12 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-api/pkg/api"
+	"mime/multipart"
 	"net/http"
 	"strings"
 )
@@ -13,11 +15,71 @@ import (
 type APIClient struct {
 	*RESTClient
 	SessionCookie *http.Cookie
+	ClientId      string
+	ClientSecret  string
 }
 
 const (
 	SessionCookie string = "JSESSIONID"
 )
+
+type HydraTokenBody struct {
+	AccessToken string `json:"access_token,omitempty"`
+	ExpiresIn   int    `json:"expires_in,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+	TokenType   string `json:"token_type,omitempty"`
+}
+
+func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
+	if hydraToken == "" {
+		glog.V(4).Infof("The hydra token is empty")
+		return "", nil
+	}
+	// the format of getting jwtToken with auth requires the following header
+	// key: x-oauth2, value: "hydra"
+	// key: x-auth-token, value: hydra access token
+	request := c.Post().Resource(api.Resource_Type_auth_token).Header("x-oauth2", "hydra").Header("x-auth-token", hydraToken)
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return "", fmt.Errorf("request %v failed: %s", request, err)
+	}
+	return response.body, nil
+}
+
+func (c *APIClient) GetHydraAccessToken() (string, error) {
+	if c.ClientId == "" || c.ClientSecret == "" {
+		glog.V(4).Infof("The client id or client secret are not provided")
+		return "", nil
+	}
+	// Create the form-data format payload
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	writer.WriteField("client_id", c.ClientId)
+	writer.WriteField("client_secret", c.ClientSecret)
+	writer.WriteField("grant_type", "client_credentials")
+	err := writer.Close()
+	if err != nil {
+		return "", fmt.Errorf("failed to Close the writer: %v", err)
+	}
+	// Create the rest api request
+	// the format of get hydra access token requires the following in the body, as form-data format
+	// key: client_id, value: client id value
+	// key: client_secret, value: client secret value
+	// key: grant_type, value: client_credentials
+	request := c.Post().Resource(api.Resource_Type_hydra_token).Header("Content-Type", writer.FormDataContentType()).BufferData(payload)
+	// Execute the request
+	response, err := request.Do()
+	if err != nil {
+		return "", fmt.Errorf("failed to get hydra access token: %s", err)
+	}
+	var hydraToken HydraTokenBody
+	err = json.Unmarshal([]byte(response.body), &hydraToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshall get hydra token response: %v", err)
+	}
+	return hydraToken.AccessToken, nil
+}
 
 // Discover a target using API
 // This function is called by turboctl which is not being maintained

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/config.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/config.go
@@ -10,13 +10,17 @@ type Config struct {
 	// For Basic authentication.
 	basicAuth *BasicAuthentication
 	// For proxy
-	proxy string
+	proxy        string
+	clientId     string
+	clientSecret string
 }
 
 type ConfigBuilder struct {
 	serverAddress *url.URL
 	basicAuth     *BasicAuthentication
 	proxy         string
+	clientId      string
+	clientSecret  string
 }
 
 func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
@@ -27,6 +31,16 @@ func NewConfigBuilder(serverAddress *url.URL) *ConfigBuilder {
 
 func (cb *ConfigBuilder) SetProxy(proxy string) *ConfigBuilder {
 	cb.proxy = proxy
+	return cb
+}
+
+func (cb *ConfigBuilder) SetClientId(clientId string) *ConfigBuilder {
+	cb.clientId = clientId
+	return cb
+}
+
+func (cb *ConfigBuilder) SetClientSecret(clientSecret string) *ConfigBuilder {
+	cb.clientSecret = clientSecret
 	return cb
 }
 
@@ -43,5 +57,7 @@ func (cb *ConfigBuilder) Create() *Config {
 		serverAddress: cb.serverAddress,
 		basicAuth:     cb.basicAuth,
 		proxy:         cb.proxy,
+		clientId:      cb.clientId,
+		clientSecret:  cb.clientSecret,
 	}
 }

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/request.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/request.go
@@ -123,6 +123,11 @@ func (r *Request) Data(data []byte) *Request {
 	return r
 }
 
+func (r *Request) BufferData(data *bytes.Buffer) *Request {
+	r.data = data
+	return r
+}
+
 // URL returns the current working URL.
 func (r *Request) URL() *url.URL {
 	p := r.pathPrefix

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/tp_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/tp_client.go
@@ -22,6 +22,14 @@ type TPClient struct {
 	*RESTClient
 }
 
+func (c *TPClient) GetJwtToken(hydraToken string) (string, error) {
+	panic("the program is trying to get jwtToken from TP Client, which should never happen")
+}
+
+func (c *TPClient) GetHydraAccessToken() (string, error) {
+	panic("the program is trying to get hydra access token from TP Client, which should never happen")
+}
+
 // DiscoverTarget adds a target via Topology Processor service
 func (c *TPClient) DiscoverTarget(uuid string) (*Result, error) {
 	// Not implemented

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/davecgh/go-spew/spew
 github.com/deckarep/golang-set
 # github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 github.com/golang/glog
-# github.com/golang/protobuf v1.5.0
+# github.com/golang/protobuf v1.5.2
 github.com/golang/protobuf/proto
 # github.com/gorilla/websocket v1.4.1
 github.com/gorilla/websocket
@@ -14,7 +14,7 @@ github.com/gorilla/websocket
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.3.0
 github.com/stretchr/testify/assert
-# github.com/turbonomic/turbo-api v0.0.0-20210715215202-c125bbe789ca
+# github.com/turbonomic/turbo-api v0.0.0-20220606151638-bcdf1d7b4ab8
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
 # google.golang.org/protobuf v1.27.1


### PR DESCRIPTION
*** Intent
For secure probe registration, we now need to acquire the jwtToken in the header of websocket connection. The review includes the changes to use the new APIs in turbo-api in https://github.com/turbonomic/turbo-api/pull/13 and use it in websocket authentication.
Please note, we still need to update the go.mod after the api is merged.

*** Implementation
This review only includes the change for SDK. More changes in Turbo go SDK and Kubeturbo. The flow is the following:

Kubeturbo load clientid and clientsecret from k8s secret
In Turbo Go SDK, clientid and clientsecret are parsed to APIClient during the creation of the client
GetHydraToken and GetJwtToken are invoked before the websocket connection.
*** Test
Use the secure probe e
![Screen Shot 2022-05-31 at 5 17 05 PM](https://user-images.githubusercontent.com/4391815/171781535-c02aebf9-4df4-407f-881c-9b015427136e.png)
nabled server and check the probe registration.
