### PR TITLE
[OM-85592]: Refresh jwt token support

### DIFF
--- a/pkg/mediationcontainer/mediation_container.go
+++ b/pkg/mediationcontainer/mediation_container.go
@@ -62,7 +62,7 @@ func CreateMediationContainer(containerConfig *MediationContainerConfig) *mediat
 }
 
 // Start the RemoteMediationClient
-func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo chan struct{}, jwtToken string) {
+func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo chan struct{}, refreshTokenChannel chan struct{}, jwTokenChannel chan string) {
 	theContainer := singletonMediationContainer()
 	glog.Infof("Initializing mediation container .....")
 	// Assert that the probes are registered before starting the handshake
@@ -74,7 +74,7 @@ func InitMediationContainer(probeRegisteredMsg chan bool, disconnectFromTurbo ch
 	glog.V(2).Infof("Registering %d probes", len(theContainer.allProbes))
 
 	remoteMediationClient := theContainer.theRemoteMediationClient
-	remoteMediationClient.Init(probeRegisteredMsg, disconnectFromTurbo, jwtToken)
+	remoteMediationClient.Init(probeRegisteredMsg, disconnectFromTurbo, refreshTokenChannel, jwTokenChannel)
 }
 
 func GetMediationService() string {

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -55,7 +55,7 @@ func CreateRemoteMediationClient(allProbes map[string]*ProbeProperties,
 
 // Establish connection with the Turbo server -  Blocks till WebSocket connection is open
 // Complete the probe registration protocol with the server and then wait for server messages
-func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh chan bool, disconnectFromTurbo chan struct{}, jwtToken string) {
+func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh chan bool, disconnectFromTurbo chan struct{}, refreshTokenChannel chan struct{}, jwTokenChannel chan string) {
 	// TODO: Assert that the probes are registered before starting the handshake ??
 
 	//// --------- Create WebSocket Transport
@@ -76,7 +76,7 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 	transport := CreateClientWebSocketTransport(connConfig) //, transportClosedNotificationCh)
 	remoteMediationClient.closeWatcherCh = make(chan bool, 1)
 
-	err = transport.Connect(jwtToken) // TODO: blocks till websocket connection is open or until transport is closed
+	err = transport.Connect(refreshTokenChannel, jwTokenChannel) // TODO: blocks till websocket connection is open or until transport is closed
 
 	// handle WebSocket creation errors
 	if err != nil { //transport.ws == nil {
@@ -117,7 +117,7 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 				// stop server messages listener
 				remoteMediationClient.stopMessageHandler()
 				// Reconnect
-				err := transport.Connect(jwtToken)
+				err := transport.Connect(refreshTokenChannel, jwTokenChannel)
 				// handle WebSocket creation errors
 				if err != nil { //transport.ws == nil {
 					glog.Errorf("[Reconnect] Initialization of remote mediation client failed: %v", err)

--- a/pkg/mediationcontainer/transport_endpoint.go
+++ b/pkg/mediationcontainer/transport_endpoint.go
@@ -3,7 +3,7 @@ package mediationcontainer
 // Transport endpoint that sends and receives raw message bytes
 type ITransport interface {
 	// Open
-	Connect(jwtToken string) error
+	Connect(refreshTokenChannel chan struct{}, jwTokenChannel chan string) error
 	GetConnectionId() string
 	GetService() string
 	// Send


### PR DESCRIPTION
Intent:
The server side has the token expiration logic to expire the jwtToken after certain interval (configurable). We need to make sure kubeturbo can refresh the jwtToken every time the websocket needs to be connected.

Implementation:
Since the websocket connection is in mediation container, and jwt Token is done through Rest API client, we decided to use separate go routine with channels in this case. See below
![Screen Shot 2022-06-13 at 5 53 47 PM](https://user-images.githubusercontent.com/4391815/173451684-5ff7fd5c-40c7-4dca-9635-f8128c41b773.png)


Test:
Tested the following scenario:
1. Probe registration with secure probe enabled, and provide client id and secret with k8s secret
2. Probe registration with secure probe disabled, without providing client id and secret
3. Re-connect by restarting TP
