### PR TITLE
[OM-88832]: Add TargetInfo during probe registration only with valid TargetIdentifier

### DIFF
--- a/pkg/probe/probe_registration.go
+++ b/pkg/probe/probe_registration.go
@@ -167,5 +167,6 @@ type IActionMergePolicyProvider interface {
 }
 
 type ISecureProbeTargetProvider interface {
+	GetTargetIdentifier() string
 	GetSecureProbeTarget() *proto.ProbeTargetInfo
 }

--- a/pkg/probe/turbo_probe.go
+++ b/pkg/probe/turbo_probe.go
@@ -271,9 +271,11 @@ func (theProbe *TurboProbe) GetProbeInfo() (*proto.ProbeInfo, error) {
 		probeInfoBuilder.WithActionMergePolicySet(registrationClient.GetActionMergePolicy())
 	}
 
-	// 9. default secure target
+	// 9. default secure target - only if the target identifier is provided
 	if registrationClient.ISecureProbeTargetProvider != nil {
-		probeInfoBuilder.WithSecureTarget(registrationClient.GetSecureProbeTarget())
+		if len(registrationClient.GetTargetIdentifier())  > 0 {
+			probeInfoBuilder.WithSecureTarget(registrationClient.GetSecureProbeTarget())
+		}
 	}
 
 	probeInfo := probeInfoBuilder.Create()

--- a/pkg/probe/turbo_probe.go
+++ b/pkg/probe/turbo_probe.go
@@ -273,7 +273,7 @@ func (theProbe *TurboProbe) GetProbeInfo() (*proto.ProbeInfo, error) {
 
 	// 9. default secure target - only if the target identifier is provided
 	if registrationClient.ISecureProbeTargetProvider != nil {
-		if len(registrationClient.GetTargetIdentifier())  > 0 {
+		if len(registrationClient.GetTargetIdentifier()) > 0 {
 			probeInfoBuilder.WithSecureTarget(registrationClient.GetSecureProbeTarget())
 		}
 	}


### PR DESCRIPTION
[PR](https://github.com/turbonomic/kubeturbo/pull/730) contains updates to kubeturbo to implement the target addition interface to provide target info details during probe registration, so a target can be automatically added to the server when it is running in secure mode.

kubeturbo users need to configure `TargetIdentifier` field before deploying the kubeturbo image. If it is not configured then the target is not automatically added and the user can add target via UI. 
We need to keep the same behavior when adding auto-adding target during probe registration.

This MR contains changes in the target addition interface in turbo-go-sdk to check if the TargetIdentifier is valid before including the TargetInfo in the `ProbeInfo`.

This will ensure that a target with empty string is not  automatically added when the probe registers.
In this case, the user will then add target manually via UI.

This was observed and tested as part of these tests carried out in this [PR](https://github.com/turbonomic/kubeturbo/pull/730)

**Tests with Secure Server**
`PreReq:` Configure the Probe client secret
`PreReq: `Do not configure Turbo Admin User
**`PreReq:` Do not configure TargetIdentifier**

Observed: Target is not added when the probe starts up and should be added manually by user via UI.


