### PR TITLE
[OM-90183]: Update turbo-api vendor and additional logging during target addition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.4.1
 	github.com/stretchr/testify v1.6.1
-	github.com/turbonomic/turbo-api v0.0.0-20221007151326-a98fd06c7a91
+	github.com/turbonomic/turbo-api v0.0.0-20221010190534-55b48bb97b1a
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.4.1
 	github.com/stretchr/testify v1.6.1
-	github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d
+	github.com/turbonomic/turbo-api v0.0.0-20221007151326-a98fd06c7a91
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.4.1
 	github.com/stretchr/testify v1.6.1
-	github.com/turbonomic/turbo-api v0.0.0-20221010190534-55b48bb97b1a
+	github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/turbonomic/turbo-api v0.0.0-20221007151326-a98fd06c7a91 h1:lcfy0Supu9WCnnbSUExcZx4iSwD8O7XMe3Kgy4o5qcc=
-github.com/turbonomic/turbo-api v0.0.0-20221007151326-a98fd06c7a91/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-api v0.0.0-20221010190534-55b48bb97b1a h1:/XUTNu7lASNxuFMHZQX9wrpK9NODdEHnQNU2q/qn2vA=
+github.com/turbonomic/turbo-api v0.0.0-20221010190534-55b48bb97b1a/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/turbonomic/turbo-api v0.0.0-20221010190534-55b48bb97b1a h1:/XUTNu7lASNxuFMHZQX9wrpK9NODdEHnQNU2q/qn2vA=
-github.com/turbonomic/turbo-api v0.0.0-20221010190534-55b48bb97b1a/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa h1:x7AkF/BAbvyJWeUd69UGqGIU96Izlz9oy9rpvsonqVI=
+github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d h1:msuY0XieGEq+a7fZdJZ3u9vH0AGpRhVZUNhJ9eUjOYY=
-github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
+github.com/turbonomic/turbo-api v0.0.0-20221007151326-a98fd06c7a91 h1:lcfy0Supu9WCnnbSUExcZx4iSwD8O7XMe3Kgy4o5qcc=
+github.com/turbonomic/turbo-api v0.0.0-20221007151326-a98fd06c7a91/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -151,7 +151,8 @@ func (wsTransport *ClientWebSocketTransport) write(mtype int, payload []byte) er
 
 // keep sending Ping msg to make sure the websocket connection is alive
 // If don't send Ping msg, *some times* the ws.ReadMessage() won't be able to
-//    know that the connection has gone.
+//
+//	know that the connection has gone.
 func (wsTransport *ClientWebSocketTransport) startPing() {
 	ticker := time.NewTicker(pingPeriod)
 	defer ticker.Stop()
@@ -172,7 +173,7 @@ func (wsTransport *ClientWebSocketTransport) startPing() {
 }
 
 // ================================================= Message Listener =============================================
-//TODO: avoid close a closed channel
+// TODO: avoid close a closed channel
 func (wsTransport *ClientWebSocketTransport) stopListenForMessages() {
 	if wsTransport.stopListenerCh != nil {
 		glog.V(4).Infof("[StopListenForMessages] closing stopListenerCh %+v", wsTransport.stopListenerCh)
@@ -184,7 +185,6 @@ func (wsTransport *ClientWebSocketTransport) stopListenForMessages() {
 // Routine to listen for messages on the websocket.
 // The websocket is continuously checked for messages and queued on the clientTransport.inputStream channel
 // Routine exits when a message is sent on clientTransport.stopListenerCh.
-//
 func (wsTransport *ClientWebSocketTransport) ListenForMessages() {
 	glog.V(3).Infof("[ListenForMessages]: ENTER  ")
 	defer close(wsTransport.inputStreamCh) //notify the receiver that websocket stop feeding data
@@ -286,6 +286,9 @@ func (wsTransport *ClientWebSocketTransport) performWebSocketConnection(refreshT
 		// blocked for jwtToken
 		refreshTokenChannel <- struct{}{}
 		jwtToken := <-jwTokenChannel
+		if len(jwtToken) > 0 {
+			glog.Infof("Trying to establish secure websocket connection...")
+		}
 		ws, service, err := openWebSocketConn(connConfig, jwtToken)
 		if err != nil {
 			// print at debug level after some time

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -129,7 +129,7 @@ func (clientProtocol *SdkClientProtocol) HandleRegistration(transport ITransport
 		return false
 	}
 
-	glog.V(2).Infof("containerInfo: %s", protobuf.MarshalTextString(containerInfo))
+	glog.V(3).Infof("containerInfo: %s", protobuf.MarshalTextString(containerInfo))
 
 	// Create Protobuf Endpoint to send and handle registration messages
 	protoMsg := &RegistrationResponse{}

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -40,16 +40,12 @@ func (tapService *TAPService) DisconnectFromTurbo() {
 // and secret configured for the probe.
 // 2. Then, the hydra token is exchanged for a JWT token by sending a request to the auth service.
 //
-// If the Hydra service returns errors or 401 (invalid credentials), this request is re-tried
+// If the Hydra service returns errors, 401 (invalid credentials) or 502 (unavailable), this request is re-tried
+// until a valid token is returned, websocket connection is not established with the server.
+// If the Auth service returns errors, 401 (invalid credentials) or 502 (unavailable), this request is re-tried
 // until a valid token is returned, websocket connection is not established with the server.
 //
-// If the Auth service returns errors, this request is re-tried
-// until a valid token is returned, websocket connection is not established with the server.
-//
-// If the Hydra service is unavailable or down (502 or 403), empty token is returned, so ConnectToTurbo() can attempt
-// to establish a non-secure websocket connection.
-//
-// If the Auth service is unavailable or down (502 or 403), empty token is returned, so ConnectToTurbo() can attempt
+// If the Hydra service is inaccessible (403) when the server is not in secure mode, empty token is returned, so ConnectToTurbo() can attempt
 // to establish a non-secure websocket connection.
 func (tapService *TAPService) getJwtToken(refreshTokenChannel chan struct{}, jwTokenChannel chan string) {
 	for {

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -20,6 +20,8 @@ type TAPService struct {
 	turboClient                 *client.TurboClient
 	disconnectFromTurbo         chan struct{}
 	communicationBindingChannel string
+	secureConnectCredentials    bool
+	turboAPICredentials         bool
 }
 
 func (tapService *TAPService) DisconnectFromTurbo() {
@@ -28,9 +30,27 @@ func (tapService *TAPService) DisconnectFromTurbo() {
 	glog.V(4).Infof("[DisconnectFromTurbo] End *********")
 }
 
-// get the jwtToken from the auth component using client id and client secret fed from k8s secret
-// client id and secret are not provided, empty jwtToken will be sent to the channel for websocket connection
-// empty jwtToken will be ignored in websocket
+// Get the jwtToken from the auth component using client id and client secret fed from k8s secret.
+// If client id and secret are not provided, empty jwtToken will be sent to the channel for websocket connection.
+// ConnectToTurbo() will attempt to establish a non-secure websocket connection.
+// Empty jwtToken will be ignored in websocket
+//
+// In order to establish a secure websocket connection with the server,
+// 1. First, a token is obtained by sending a http request to the Hydra service (OAuth Client) using the client id
+// and secret configured for the probe.
+// 2. Then, the hydra token is exchanged for a JWT token by sending a request to the auth service.
+//
+// If the Hydra service returns errors or 401 (invalid credentials), this request is re-tried
+// until a valid token is returned, websocket connection is not established with the server.
+//
+// If the Auth service returns errors, this request is re-tried
+// until a valid token is returned, websocket connection is not established with the server.
+//
+// If the Hydra service is unavailable or down (502 or 403), empty token is returned, so ConnectToTurbo() can attempt
+// to establish a non-secure websocket connection.
+//
+// If the Auth service is unavailable or down (502 or 403), empty token is returned, so ConnectToTurbo() can attempt
+// to establish a non-secure websocket connection.
 func (tapService *TAPService) getJwtToken(refreshTokenChannel chan struct{}, jwTokenChannel chan string) {
 	for {
 		// blocked by isActive
@@ -44,7 +64,7 @@ func (tapService *TAPService) getJwtToken(refreshTokenChannel chan struct{}, jwT
 		for {
 			hydraToken, err = tapService.turboClient.GetHydraAccessToken()
 			if err != nil {
-				glog.Errorf("Failed to get hydra token due to %v, retry in 30s", err)
+				glog.Errorf("Failed to get hydra token: [%v], retry in 30s", err)
 				time.Sleep(time.Second * 30)
 			} else {
 				break
@@ -53,11 +73,15 @@ func (tapService *TAPService) getJwtToken(refreshTokenChannel chan struct{}, jwT
 		for {
 			jwtToken, err = tapService.turboClient.GetJwtToken(hydraToken)
 			if err != nil {
-				glog.Errorf("Failed to get jwt token due to %v, retry in 30s", err)
+				glog.Errorf("Failed to get jwt token: [%v], retry in 30s", err)
 				time.Sleep(time.Second * 30)
 			} else {
+
 				break
 			}
+		}
+		if len(jwtToken) > 0 {
+			glog.V(3).Infof("Obtained jwt auth token")
 		}
 		// send jwt Token back
 		jwTokenChannel <- jwtToken
@@ -78,14 +102,31 @@ func (tapService *TAPService) addTarget(isRegistered chan bool) {
 		return
 	}
 
+	// Since the Turbo API credentials are not available, TAP service cannot connect to add target
+	if !tapService.turboAPICredentials {
+		glog.Errorf("Turbo API credentials are not provided, " +
+			"cannot connect to turbo api to query target information")
+		// Since the probe is configured with secure server connection credentials
+		// and if the server is running in secure mode, target was automatically added during probe registration
+		if tapService.secureConnectCredentials {
+			// Target is added during probe registration
+			glog.Infof("Target %s could be auto-registered if the server is running in secure mode",
+				tapService.TurboProbe.RegistrationClient.ISecureProbeTargetProvider.GetTargetIdentifier())
+		} else {
+			// Target needs to be manually added
+			glog.Infof("Need to manually add target via UI for target type %s",
+				tapService.TurboProbe.ProbeConfiguration.ProbeType)
+		}
+		return
+	}
+
 	for _, targetInfo := range targetInfos {
 		target := targetInfo.GetTargetInstance()
 		target.InputFields = append(target.InputFields, &api.InputField{
 			Name: api.CommunicationBindingChannel, Value: tapService.communicationBindingChannel})
 		service := mediationcontainer.GetMediationService()
 		if err := tapService.turboClient.AddTarget(target, service); err != nil {
-			glog.Errorf("Failed to add target %v: %v",
-				targetInfo, err)
+			glog.Errorf("Target %v not added via api: %v", targetInfo, err)
 		}
 	}
 }
@@ -163,6 +204,9 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 		CommunicationBindingChannel: builder.tapService.communicationBindingChannel,
 	}
 	mediationcontainer.CreateMediationContainer(containerConfig)
+
+	builder.tapService.secureConnectCredentials = commConfig.SecureModeCredentialsProvided()
+	builder.tapService.turboAPICredentials = commConfig.TurboAPICredentialsProvided()
 
 	// The RestAPI Handler
 	serverAddress, err := url.Parse(commConfig.TurboServer)

--- a/pkg/service/turbo_communication_config.go
+++ b/pkg/service/turbo_communication_config.go
@@ -48,6 +48,20 @@ func (turboCommConfig *TurboCommunicationConfig) ValidateTurboCommunicationConfi
 	return nil
 }
 
+func (turboCommConfig *TurboCommunicationConfig) SecureModeCredentialsProvided() bool {
+	if len(turboCommConfig.ClientSecret) > 0 && len(turboCommConfig.ClientSecret) > 0 {
+		return true
+	}
+	return false
+}
+
+func (turboCommConfig *TurboCommunicationConfig) TurboAPICredentialsProvided() bool {
+	if len(turboCommConfig.OpsManagerPassword) > 0 && len(turboCommConfig.OpsManagerPassword) > 0 {
+		return true
+	}
+	return false
+}
+
 func ParseTurboCommunicationConfig(configFile string) (*TurboCommunicationConfig, error) {
 	// load the config
 	turboCommConfig, err := readTurboCommunicationConfig(configFile)

--- a/pkg/service/turbo_communication_config.go
+++ b/pkg/service/turbo_communication_config.go
@@ -49,14 +49,14 @@ func (turboCommConfig *TurboCommunicationConfig) ValidateTurboCommunicationConfi
 }
 
 func (turboCommConfig *TurboCommunicationConfig) SecureModeCredentialsProvided() bool {
-	if len(turboCommConfig.ClientSecret) > 0 && len(turboCommConfig.ClientSecret) > 0 {
+	if len(turboCommConfig.ClientSecret) > 0 && len(turboCommConfig.ClientId) > 0 {
 		return true
 	}
 	return false
 }
 
 func (turboCommConfig *TurboCommunicationConfig) TurboAPICredentialsProvided() bool {
-	if len(turboCommConfig.OpsManagerPassword) > 0 && len(turboCommConfig.OpsManagerPassword) > 0 {
+	if len(turboCommConfig.OpsManagerUsername) > 0 && len(turboCommConfig.OpsManagerPassword) > 0 {
 		return true
 	}
 	return false

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
@@ -44,11 +44,23 @@ func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("request to exchange for auth token %v failed: %s", request, err)
 	}
-	if response.statusCode == 502 || response.statusCode == 403 {
-		// When we receive the 502 or 403 status code, meaning the auth service is currently not available.
+	if response.statusCode == 401 {
+		// When we receive the 401 status code, means that the credentials are not valid.
+		// We return error, so getJwtToken() method in tap_service will continue
+		// to retry authentication until the credentials are corrected
+		return "", fmt.Errorf("Auth service authentication failed using the given client_id and secret")
+	}
+	if response.statusCode == 403 {
+		// When we receive the 403 status code, meaning the security feature is currently not available.
 		// We will retry websocket connection without the JWTToken
 		glog.Errorf("Auth service is not accessible or disabled [%v:%s]", response.statusCode, response.status)
 		return "", nil
+	}
+	if response.statusCode == 502 {
+		// When we receive the 502 status code, meaning the auth service is currently not available.
+		// We return error, so getJwtToken() method in tap_service will continue
+		// to retry authentication until the service is restored
+		return "", fmt.Errorf("Auth service is not available [%v:%s]", response.statusCode, response.status)
 	}
 	return response.body, nil
 }
@@ -85,8 +97,15 @@ func (c *APIClient) GetHydraAccessToken() (string, error) {
 		// to retry authentication until the credentials are corrected
 		return "", fmt.Errorf("Hydra service authentication failed using the given client_id and secret")
 	}
-	if response.statusCode == 403 || response.statusCode == 502 {
-		// When we receive the 403 status code, meaning the hydra service is currently not available.
+	if response.statusCode == 502 {
+		// When we receive the 502 status code, meaning the hydra service is currently not available.
+		// We return error, so getJwtToken() method in tap_service will continue
+		// to retry authentication until the service is restored
+		return "", fmt.Errorf("Hydra service is not available [%v:%s]", response.statusCode, response.status)
+	}
+	if response.statusCode == 403 {
+		// When we receive the 403 status code, means that the hydra service is currently not available,
+		// This is when the security feature is not available.
 		// We are not returning error here to handle the case when customer enabled probe security in the first place then disabled
 		// In the case above, there'll be client_id and secret in the k8s secret, but we shouldn't use them in websocket connection
 		// If the hydra service is temporarily not accessible, we have retry in performWebSocketConnection in turbo-go-sdk

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
@@ -42,7 +42,13 @@ func (c *APIClient) GetJwtToken(hydraToken string) (string, error) {
 	// Execute the request
 	response, err := request.Do()
 	if err != nil {
-		return "", fmt.Errorf("request %v failed: %s", request, err)
+		return "", fmt.Errorf("request to exchange for auth token %v failed: %s", request, err)
+	}
+	if response.statusCode == 502 || response.statusCode == 403 {
+		// When we receive the 502 or 403 status code, meaning the auth service is currently not available.
+		// We will retry websocket connection without the JWTToken
+		glog.Errorf("Auth service is not accessible or disabled [%v:%s]", response.statusCode, response.status)
+		return "", nil
 	}
 	return response.body, nil
 }
@@ -73,12 +79,18 @@ func (c *APIClient) GetHydraAccessToken() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get hydra access token: %s", err)
 	}
-	if response.statusCode == 403 {
+	if response.statusCode == 401 {
+		// When we receive the 401 status code, means that the credentials are not valid.
+		// We return error, so getJwtToken() method in tap_service will continue
+		// to retry authentication until the credentials are corrected
+		return "", fmt.Errorf("Hydra service authentication failed using the given client_id and secret")
+	}
+	if response.statusCode == 403 || response.statusCode == 502 {
 		// When we receive the 403 status code, meaning the hydra service is currently not available.
 		// We are not returning error here to handle the case when customer enabled probe security in the first place then disabled
 		// In the case above, there'll be client_id and secret in the k8s secret, but we shouldn't use them in websocket connection
 		// If the hydra service is temporarily not accessible, we have retry in performWebSocketConnection in turbo-go-sdk
-		glog.Errorf("Hydra service is not accessible or disabled")
+		glog.Errorf("Hydra service is not accessible or disabled [%v:%s]", response.statusCode, response.status)
 		return "", nil
 	}
 	var hydraToken HydraTokenBody

--- a/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
+++ b/vendor/github.com/turbonomic/turbo-api/pkg/client/api_client.go
@@ -95,7 +95,8 @@ func (c *APIClient) GetHydraAccessToken() (string, error) {
 		// When we receive the 401 status code, means that the credentials are not valid.
 		// We return error, so getJwtToken() method in tap_service will continue
 		// to retry authentication until the credentials are corrected
-		return "", fmt.Errorf("Hydra service authentication failed using the given client_id and secret")
+		return "", fmt.Errorf("Hydra service authentication failed using the given client_id and secret. " +
+			"Redeploy the secret containing the correct credentials and restart the probe pod")
 	}
 	if response.statusCode == 502 {
 		// When we receive the 502 status code, meaning the hydra service is currently not available.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,7 +14,7 @@ github.com/gorilla/websocket
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert
-# github.com/turbonomic/turbo-api v0.0.0-20221007151326-a98fd06c7a91
+# github.com/turbonomic/turbo-api v0.0.0-20221010190534-55b48bb97b1a
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
 # google.golang.org/protobuf v1.27.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,7 +14,7 @@ github.com/gorilla/websocket
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert
-# github.com/turbonomic/turbo-api v0.0.0-20220725155952-ec41db73695d
+# github.com/turbonomic/turbo-api v0.0.0-20221007151326-a98fd06c7a91
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
 # google.golang.org/protobuf v1.27.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,7 +14,7 @@ github.com/gorilla/websocket
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.6.1
 github.com/stretchr/testify/assert
-# github.com/turbonomic/turbo-api v0.0.0-20221010190534-55b48bb97b1a
+# github.com/turbonomic/turbo-api v0.0.0-20221010220448-3f35ebf030aa
 github.com/turbonomic/turbo-api/pkg/api
 github.com/turbonomic/turbo-api/pkg/client
 # google.golang.org/protobuf v1.27.1


### PR DESCRIPTION
Need to update the turbo-api in vendor directory for turbo-go-sdk based on the changes from 
[this PR](https://github.com/turbonomic/turbo-api/pull/15).

Additionally added some logging while attempting to add probe target via API. 
Currently, this mechanism is still retained since the server can run in secure or non-secure mode.

See some examples below.
When the server runs in secure mode, and if  the probe is **able to establish a secure websocket** connection to the server , its target is also automatically registered in the server.
-  The probe (`TAPService`) will also try to add target via the API, if and only if the Turbo admin API credentials are still configured. In this case, however, since the target already exists, the API call will simply return.

<img width="1108" alt="Screen Shot 2022-10-07 at 3 37 59 PM" src="https://user-images.githubusercontent.com/11964436/194645585-10355a98-6a56-4a3f-aafc-71a768f3c3fa.png">


- If the Turbo admin API credentials are no longer configured, the probe ([TAPService](url)) cannot login to the API and target addition will not be attempted.
<img width="1183" alt="Screen Shot 2022-10-07 at 4 02 40 PM" src="https://user-images.githubusercontent.com/11964436/194645678-28c30f97-7985-4cd8-8f9e-e3dbe74aa143.png">


In non-secure server, the `TAPService` will attempt target addition via the API and a target will be added only if the Turbo admin API credentials. If not, user will need to manually add the target.

<img width="1242" alt="Screen Shot 2022-10-07 at 3 21 03 PM" src="https://user-images.githubusercontent.com/11964436/194646128-6b0fb4dc-bea7-4b79-8895-8f209be9d694.png">





