### PR TITLE
[OM-91918]: Decrease ping interval to 30 seconds.

### DIFF
--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -23,7 +23,7 @@ const (
 	handshakeTimeout                 = 60 * time.Second
 	wsReadLimit                      = 33554432 // 32 MB
 	writeWaitTimeout                 = 120 * time.Second
-	pingPeriod                       = 60 * time.Second
+	pingPeriod                       = 30 * time.Second
 )
 
 type TransportStatus string


### PR DESCRIPTION
## Intent
Decrease ping interval to 30 seconds.

## Background
Default load balancers will typically implement a 60 second timeout. If there is no activity detected, the connection will be closed.  This poses a potential issue in that the secure WebSocket communication created by Kubeturbo can potentially be closed due to exceeding that default timeout when our ping interval is set to the same value.

## Testing
Ran Kubeturbo locally with changes and verified that pings we sent at 30 seconds intervals.

```
I1114 10:07:56.987494   46340 client_websocket_transport.go:165] begin to send Ping message
I1114 10:07:57.015493   46340 client_websocket_transport.go:335] Received pong msg
I1114 10:08:26.988483   46340 client_websocket_transport.go:165] begin to send Ping message
I1114 10:08:27.021533   46340 client_websocket_transport.go:335] Received pong msg
I1114 10:08:56.988637   46340 client_websocket_transport.go:165] begin to send Ping message
I1114 10:08:57.290780   46340 client_websocket_transport.go:335] Received pong msg
```

