### PR TITLE
[OM-93675]: Add container spec data to the entity dto 

### DIFF
--- a/pkg/builder/entity_dto_builder.go
+++ b/pkg/builder/entity_dto_builder.go
@@ -179,7 +179,7 @@ func (eb *EntityDTOBuilder) Create() (*proto.EntityDTO, error) {
 		entityDTO.EntityData = &proto.EntityDTO_NamespaceData_{eb.namespaceData}
 	} else if eb.clusterData != nil {
 		entityDTO.EntityData = &proto.EntityDTO_ContainerPlatformClusterData_{eb.clusterData}
-	} else if eb.ContainerSpecData != nil {
+	} else if eb.containerSpecData != nil {
 		entityDTO.EntityData = &proto.EntityDTO_ContainerSpecData_{eb.containerSpecData}
 	}
 

--- a/pkg/builder/entity_dto_builder.go
+++ b/pkg/builder/entity_dto_builder.go
@@ -179,6 +179,8 @@ func (eb *EntityDTOBuilder) Create() (*proto.EntityDTO, error) {
 		entityDTO.EntityData = &proto.EntityDTO_NamespaceData_{eb.namespaceData}
 	} else if eb.clusterData != nil {
 		entityDTO.EntityData = &proto.EntityDTO_ContainerPlatformClusterData_{eb.clusterData}
+	} else if eb.ContainerSpecData != nil {
+		entityDTO.EntityData = &proto.EntityDTO_ContainerSpecData_{eb.containerSpecData}
 	}
 
 	if eb.virtualMachineRelatedData != nil {


### PR DESCRIPTION
Additional change required for this [PR](https://github.com/turbonomic/turbo-go-sdk/pull/144), so the ContainerSpec data is added to the EntityDTO protobuf message