### PR TITLE
[OM-100430]: TAP service configuration option to increase timeout to complete registration with server

### DIFF
--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -227,7 +227,7 @@ func (wsTransport *ClientWebSocketTransport) ListenForMessages() {
 				//notify upper module that this connection is closed
 				wsTransport.connClosedNotificationCh <- true // Note: this will block till the message is received
 
-				glog.V(1).Infof("[ListenForMessages] websocket error notified, stop lisening for messages.")
+				glog.V(1).Infof("[ListenForMessages] websocket error notified, stop listening for messages.")
 				return
 			}
 			// write the message on the channel

--- a/pkg/mediationcontainer/client_websocket_transport_test.go
+++ b/pkg/mediationcontainer/client_websocket_transport_test.go
@@ -55,8 +55,8 @@ func TestCreateClientWebSocketTransport(t *testing.T) {
 			},
 			item.bindingChannel,
 			SdkProtocolConfig{
-				RegistrationTimeoutSec:        30,
-				ExitProbePodOnProtocolTimeout: false,
+				RegistrationTimeoutSec:       60,
+				RestartOnRegistrationTimeout: false,
 			},
 		}
 		wsConfig, err := CreateWebSocketConnectionConfig(containerConfig)
@@ -77,8 +77,8 @@ func TestCreateClientWebSocketTransport(t *testing.T) {
 				},
 				item.bindingChannel,
 				SdkProtocolConfig{
-					RegistrationTimeoutSec:        30,
-					ExitProbePodOnProtocolTimeout: false,
+					RegistrationTimeoutSec:       60,
+					RestartOnRegistrationTimeout: false,
 				},
 			}
 			if !reflect.DeepEqual(expectedWebSocketConfig, wsConfig) {

--- a/pkg/mediationcontainer/client_websocket_transport_test.go
+++ b/pkg/mediationcontainer/client_websocket_transport_test.go
@@ -54,6 +54,10 @@ func TestCreateClientWebSocketTransport(t *testing.T) {
 				LocalAddress: item.localAddress,
 			},
 			item.bindingChannel,
+			SdkProtocolConfig{
+				RegistrationTimeoutSec: 30,
+				ExitOnProtocolTimeout:  false,
+			},
 		}
 		wsConfig, err := CreateWebSocketConnectionConfig(containerConfig)
 		if item.expectsErr {
@@ -72,6 +76,10 @@ func TestCreateClientWebSocketTransport(t *testing.T) {
 					LocalAddress: item.localAddress,
 				},
 				item.bindingChannel,
+				SdkProtocolConfig{
+					RegistrationTimeoutSec: 30,
+					ExitOnProtocolTimeout:  false,
+				},
 			}
 			if !reflect.DeepEqual(expectedWebSocketConfig, wsConfig) {
 				t.Errorf("\nExpect %v,\n got   %v", expectedWebSocketConfig, wsConfig)

--- a/pkg/mediationcontainer/client_websocket_transport_test.go
+++ b/pkg/mediationcontainer/client_websocket_transport_test.go
@@ -55,8 +55,8 @@ func TestCreateClientWebSocketTransport(t *testing.T) {
 			},
 			item.bindingChannel,
 			SdkProtocolConfig{
-				RegistrationTimeoutSec: 30,
-				ExitOnProtocolTimeout:  false,
+				RegistrationTimeoutSec:        30,
+				ExitProbePodOnProtocolTimeout: false,
 			},
 		}
 		wsConfig, err := CreateWebSocketConnectionConfig(containerConfig)
@@ -77,8 +77,8 @@ func TestCreateClientWebSocketTransport(t *testing.T) {
 				},
 				item.bindingChannel,
 				SdkProtocolConfig{
-					RegistrationTimeoutSec: 30,
-					ExitOnProtocolTimeout:  false,
+					RegistrationTimeoutSec:        30,
+					ExitProbePodOnProtocolTimeout: false,
 				},
 			}
 			if !reflect.DeepEqual(expectedWebSocketConfig, wsConfig) {

--- a/pkg/mediationcontainer/mediation_communication_config.go
+++ b/pkg/mediationcontainer/mediation_communication_config.go
@@ -70,8 +70,8 @@ func (wsc *WebSocketConfig) ValidateWebSocketConfig() error {
 }
 
 type SdkProtocolConfig struct {
-	RegistrationTimeoutSec int
-	ExitOnProtocolTimeout  bool
+	RegistrationTimeoutSec        int
+	ExitProbePodOnProtocolTimeout bool
 }
 
 type MediationContainerConfig struct {

--- a/pkg/mediationcontainer/mediation_communication_config.go
+++ b/pkg/mediationcontainer/mediation_communication_config.go
@@ -69,9 +69,12 @@ func (wsc *WebSocketConfig) ValidateWebSocketConfig() error {
 	return nil
 }
 
+// Configuration options used when establishing sdk protocol connection with the server
 type SdkProtocolConfig struct {
-	RegistrationTimeoutSec        int
-	ExitProbePodOnProtocolTimeout bool
+	// Probe registration response timeout
+	RegistrationTimeoutSec int
+	// If the probe container should exit if there is timeout during probe registration
+	RestartOnRegistrationTimeout bool
 }
 
 type MediationContainerConfig struct {

--- a/pkg/mediationcontainer/mediation_communication_config.go
+++ b/pkg/mediationcontainer/mediation_communication_config.go
@@ -3,11 +3,10 @@ package mediationcontainer
 import (
 	"errors"
 	"fmt"
-	"net/url"
-
 	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-api/pkg/client"
 	"github.com/turbonomic/turbo-go-sdk/pkg/version"
+	"net/url"
 )
 
 var (
@@ -18,6 +17,11 @@ var (
 	defaultRemoteMediationServerUser   = "vmtRemoteMediation"
 	defaultRemoteMediationServerPwd    = "vmtRemoteMediation"
 	defaultRemoteMediationLocalAddress = "http://127.0.0.1"
+)
+
+const (
+	DefaultRegistrationTimeOut          = 300
+	DefaultRegistrationTimeoutThreshold = 60
 )
 
 type ServerMeta struct {
@@ -72,9 +76,24 @@ func (wsc *WebSocketConfig) ValidateWebSocketConfig() error {
 // Configuration options used when establishing sdk protocol connection with the server
 type SdkProtocolConfig struct {
 	// Probe registration response timeout
-	RegistrationTimeoutSec int
+	RegistrationTimeoutSec int `json:"registrationTimeoutSec,omitempty"`
 	// If the probe container should exit if there is timeout during probe registration
-	RestartOnRegistrationTimeout bool
+	RestartOnRegistrationTimeout bool `json:"restartOnRegistrationTimeout,omitempty"`
+}
+
+func (sdkProtocolConfig *SdkProtocolConfig) ValidateSdkProtocolConfig() error {
+	glog.Infof("SdkProtocolConfig from config file [%++v]", sdkProtocolConfig)
+
+	// Default to 300 seconds if the timeout is less than 60 seconds
+	if sdkProtocolConfig.RegistrationTimeoutSec < DefaultRegistrationTimeoutThreshold {
+		glog.Warningf("Changing invalid 'RegistrationTimeoutSec' config [%v] to default %v",
+			sdkProtocolConfig.RegistrationTimeoutSec, DefaultRegistrationTimeOut)
+		sdkProtocolConfig.RegistrationTimeoutSec = DefaultRegistrationTimeOut
+	}
+
+	glog.Infof("Validated SdkProtocolConfig [%++v]: ", sdkProtocolConfig)
+
+	return nil
 }
 
 type MediationContainerConfig struct {
@@ -90,6 +109,9 @@ func (containerConfig *MediationContainerConfig) ValidateMediationContainerConfi
 		return err
 	}
 	if err := containerConfig.ValidateWebSocketConfig(); err != nil {
+		return err
+	}
+	if err := containerConfig.ValidateSdkProtocolConfig(); err != nil {
 		return err
 	}
 	glog.V(4).Infof("The mediation container config is %v", containerConfig)

--- a/pkg/mediationcontainer/mediation_communication_config.go
+++ b/pkg/mediationcontainer/mediation_communication_config.go
@@ -69,10 +69,16 @@ func (wsc *WebSocketConfig) ValidateWebSocketConfig() error {
 	return nil
 }
 
+type SdkProtocolConfig struct {
+	RegistrationTimeoutSec int
+	ExitOnProtocolTimeout  bool
+}
+
 type MediationContainerConfig struct {
 	ServerMeta
 	WebSocketConfig
 	CommunicationBindingChannel string
+	SdkProtocolConfig
 }
 
 // Validate the mediation container config and set default value if necessary.

--- a/pkg/mediationcontainer/mediation_communication_config_test.go
+++ b/pkg/mediationcontainer/mediation_communication_config_test.go
@@ -1,6 +1,7 @@
 package mediationcontainer
 
 import (
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 
@@ -222,6 +223,48 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
+		}
+	}
+}
+
+func TestValidateSdkProtocolConfig(t *testing.T) {
+	table := []struct {
+		config   *SdkProtocolConfig
+		expected *SdkProtocolConfig
+	}{
+		{
+			config: &SdkProtocolConfig{},
+			expected: &SdkProtocolConfig{
+				RegistrationTimeoutSec:       DefaultRegistrationTimeOut,
+				RestartOnRegistrationTimeout: false,
+			},
+		},
+		{
+			config: &SdkProtocolConfig{
+				RegistrationTimeoutSec:       30,
+				RestartOnRegistrationTimeout: true,
+			},
+			expected: &SdkProtocolConfig{
+				RegistrationTimeoutSec:       DefaultRegistrationTimeOut,
+				RestartOnRegistrationTimeout: true,
+			},
+		},
+		{
+			config: &SdkProtocolConfig{
+				RegistrationTimeoutSec: 600,
+			},
+			expected: &SdkProtocolConfig{
+				RegistrationTimeoutSec:       600,
+				RestartOnRegistrationTimeout: false,
+			},
+		},
+	}
+	for _, item := range table {
+		item.config.ValidateSdkProtocolConfig()
+
+		if item.expected != nil {
+			assert.Equal(t, item.expected.RegistrationTimeoutSec, item.config.RegistrationTimeoutSec)
+			assert.Equal(t, item.expected.RestartOnRegistrationTimeout, item.config.RestartOnRegistrationTimeout)
 		}
 	}
 }

--- a/pkg/mediationcontainer/mediation_communication_config_test.go
+++ b/pkg/mediationcontainer/mediation_communication_config_test.go
@@ -161,6 +161,10 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 					ConnectionRetry:   10,
 				},
 				"",
+				SdkProtocolConfig{
+					RegistrationTimeoutSec: 30,
+					ExitOnProtocolTimeout:  false,
+				},
 			},
 			expectErr: true,
 		},
@@ -173,6 +177,10 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 					LocalAddress: "invalid",
 				},
 				"foo",
+				SdkProtocolConfig{
+					RegistrationTimeoutSec: 30,
+					ExitOnProtocolTimeout:  false,
+				},
 			},
 			expectErr: true,
 		},

--- a/pkg/mediationcontainer/mediation_communication_config_test.go
+++ b/pkg/mediationcontainer/mediation_communication_config_test.go
@@ -162,8 +162,27 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 				},
 				"",
 				SdkProtocolConfig{
-					RegistrationTimeoutSec:        30,
-					ExitProbePodOnProtocolTimeout: false,
+					RegistrationTimeoutSec:       60,
+					RestartOnRegistrationTimeout: false,
+				},
+			},
+			expectErr: true,
+		},
+		{
+			containerConfig: &MediationContainerConfig{
+				ServerMeta{
+					TurboServer: "invalid",
+				},
+				WebSocketConfig{
+					LocalAddress:      "http://127.0.0.1",
+					WebSocketUsername: rand.String(10),
+					WebSocketPassword: rand.String(10),
+					ConnectionRetry:   10,
+				},
+				"",
+				SdkProtocolConfig{
+					RegistrationTimeoutSec:       60,
+					RestartOnRegistrationTimeout: true,
 				},
 			},
 			expectErr: true,
@@ -178,8 +197,8 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 				},
 				"foo",
 				SdkProtocolConfig{
-					RegistrationTimeoutSec:        30,
-					ExitProbePodOnProtocolTimeout: false,
+					RegistrationTimeoutSec:       60,
+					RestartOnRegistrationTimeout: false,
 				},
 			},
 			expectErr: true,

--- a/pkg/mediationcontainer/mediation_communication_config_test.go
+++ b/pkg/mediationcontainer/mediation_communication_config_test.go
@@ -162,8 +162,8 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 				},
 				"",
 				SdkProtocolConfig{
-					RegistrationTimeoutSec: 30,
-					ExitOnProtocolTimeout:  false,
+					RegistrationTimeoutSec:        30,
+					ExitProbePodOnProtocolTimeout: false,
 				},
 			},
 			expectErr: true,
@@ -178,8 +178,8 @@ func TestMediationContainerConfig_ValidateMediationContainerConfig(t *testing.T)
 				},
 				"foo",
 				SdkProtocolConfig{
-					RegistrationTimeoutSec: 30,
-					ExitOnProtocolTimeout:  false,
+					RegistrationTimeoutSec:        30,
+					ExitProbePodOnProtocolTimeout: false,
 				},
 			},
 			expectErr: true,

--- a/pkg/mediationcontainer/remote_mediation_client.go
+++ b/pkg/mediationcontainer/remote_mediation_client.go
@@ -70,7 +70,9 @@ func (remoteMediationClient *remoteMediationClient) Init(probeRegisteredMsgCh ch
 
 	// Sdk Protocol handler
 	sdkProtocolHandler := CreateSdkClientProtocolHandler(remoteMediationClient.allProbes,
-		remoteMediationClient.containerConfig.Version, remoteMediationClient.containerConfig.CommunicationBindingChannel)
+		remoteMediationClient.containerConfig.Version,
+		remoteMediationClient.containerConfig.CommunicationBindingChannel,
+		&remoteMediationClient.containerConfig.SdkProtocolConfig)
 	// ------ Websocket transport
 
 	transport := CreateClientWebSocketTransport(connConfig) //, transportClosedNotificationCh)

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -12,10 +12,6 @@ import (
 	"github.com/golang/glog"
 )
 
-const (
-	waitRegistrationResponseTimeOut = time.Second * 300
-)
-
 type SdkClientProtocol struct {
 	allProbes                    map[string]*ProbeProperties
 	version                      string
@@ -27,11 +23,11 @@ type SdkClientProtocol struct {
 func CreateSdkClientProtocolHandler(allProbes map[string]*ProbeProperties, version, communicationBindingChannel string,
 	sdkProtocolConfig *SdkProtocolConfig) *SdkClientProtocol {
 
-	registrationResponseTimeout := waitRegistrationResponseTimeOut
+	registrationResponseTimeout := time.Second * DefaultRegistrationTimeOut
 	restartOnRegistrationTimeout := false
 
 	if sdkProtocolConfig != nil {
-		if sdkProtocolConfig.RegistrationTimeoutSec >= 60 {
+		if sdkProtocolConfig.RegistrationTimeoutSec >= DefaultRegistrationTimeoutThreshold {
 			var timeout time.Duration
 			timeout = time.Duration(sdkProtocolConfig.RegistrationTimeoutSec)
 			registrationResponseTimeout = time.Second * timeout

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -18,37 +18,37 @@ const (
 )
 
 type SdkClientProtocol struct {
-	allProbes                         map[string]*ProbeProperties
-	version                           string
-	communicationBindingChannel       string
-	waitRegistrationResponseTimeOut   time.Duration
-	exitOnRegistrationResponseTimeOut bool
+	allProbes                              map[string]*ProbeProperties
+	version                                string
+	communicationBindingChannel            string
+	waitRegistrationResponseTimeOut        time.Duration
+	exitProbeOnRegistrationResponseTimeOut bool
 	//TransportReady chan bool
 }
 
 func CreateSdkClientProtocolHandler(allProbes map[string]*ProbeProperties, version, communicationBindingChannel string,
 	sdkProtocolConfig *SdkProtocolConfig) *SdkClientProtocol {
 	var defaultResponseTimeOut time.Duration
-	var exitOnRegistrationResponseTimeOut bool
+	var exitProbeOnRegistrationResponseTimeOut bool
 
 	if sdkProtocolConfig == nil {
 		defaultResponseTimeOut = waitRegistrationResponseTimeOut
-		exitOnRegistrationResponseTimeOut = true
+		exitProbeOnRegistrationResponseTimeOut = false
 	} else {
 		var timeout time.Duration
 		timeout = time.Duration(sdkProtocolConfig.RegistrationTimeoutSec)
 
 		defaultResponseTimeOut = time.Second * timeout
-		exitOnRegistrationResponseTimeOut = sdkProtocolConfig.ExitOnProtocolTimeout
+		exitProbeOnRegistrationResponseTimeOut = sdkProtocolConfig.ExitProbePodOnProtocolTimeout
 	}
 	glog.Infof("**** SDK Protocol timeout related config [%++v]", sdkProtocolConfig)
 
 	return &SdkClientProtocol{
-		allProbes:                         allProbes,
-		version:                           version,
-		communicationBindingChannel:       communicationBindingChannel,
-		waitRegistrationResponseTimeOut:   defaultResponseTimeOut,
-		exitOnRegistrationResponseTimeOut: exitOnRegistrationResponseTimeOut,
+		allProbes:                              allProbes,
+		version:                                version,
+		communicationBindingChannel:            communicationBindingChannel,
+		waitRegistrationResponseTimeOut:        defaultResponseTimeOut,
+		exitProbeOnRegistrationResponseTimeOut: exitProbeOnRegistrationResponseTimeOut,
 		//TransportReady: done,
 	}
 }
@@ -68,7 +68,7 @@ func (clientProtocol *SdkClientProtocol) handleClientProtocol(transport ITranspo
 	if !status {
 		glog.Errorf("Failure during Registration, cannot receive server messages")
 		// panic here ... so Kubernetes can restart the probe pod
-		if clientProtocol.exitOnRegistrationResponseTimeOut {
+		if clientProtocol.exitProbeOnRegistrationResponseTimeOut {
 			panic("********* PANIC: Failure during Registration **********")
 			os.Exit(1)
 		}

--- a/pkg/mediationcontainer/sdk_client_protocol.go
+++ b/pkg/mediationcontainer/sdk_client_protocol.go
@@ -69,7 +69,7 @@ func (clientProtocol *SdkClientProtocol) handleClientProtocol(transport ITranspo
 		glog.Errorf("Failure during Registration, cannot receive server messages")
 		// panic here ... so Kubernetes can restart the probe pod
 		if clientProtocol.exitProbeOnRegistrationResponseTimeOut {
-			panic("********* PANIC: Failure during Registration **********")
+			panic("********* Failure during Registration **********")
 			os.Exit(1)
 		}
 		transportReady <- false
@@ -123,18 +123,18 @@ func (clientProtocol *SdkClientProtocol) NegotiateVersion(transport ITransport) 
 	endpoint.Send(endMsg)
 
 	// Wait for the response to be received by the transport and then parsed and put on the endpoint's message channel
-	negotitatonStartTime := time.Now()
+	negotiationStartTime := time.Now()
 	serverMsg, err := timeOutRead(endpoint.GetName(), clientProtocol.waitRegistrationResponseTimeOut, endpoint.MessageReceiver())
 	if err != nil {
 		glog.V(2).Infof("[%s] : Error during version negotiation: %+v, disconnecting from server", endpoint.GetName(), err)
 		glog.Errorf("[%s] : read VersionNegotiation response from channel failed: %v", endpoint.GetName(), err)
 		return false
 	}
-	negotitatonEndTime := time.Now()
-	negotitatonTime := negotitatonEndTime.Sub(negotitatonStartTime)
+	negotiationEndTime := time.Now()
+	negotiationTime := negotiationEndTime.Sub(negotiationStartTime)
 
 	glog.V(2).Infof("[%s] : Received VersionNegotiation response after %v ",
-		endpoint.GetName(), negotitatonTime)
+		endpoint.GetName(), negotiationTime)
 
 	glog.V(4).Infof("[%s] : Received: %+v", endpoint.GetName(), serverMsg)
 

--- a/pkg/mediationcontainer/sdk_client_protocol_test.go
+++ b/pkg/mediationcontainer/sdk_client_protocol_test.go
@@ -10,8 +10,19 @@ import (
 func TestCreateSdkClientProtocolHandler(t *testing.T) {
 	communicationBindingChannel := "foo"
 	sdkClientProtocol := CreateSdkClientProtocolHandler(nil, "1.0", communicationBindingChannel, nil)
-	assert.Equal(t, time.Duration(300000000000), sdkClientProtocol.waitRegistrationResponseTimeOut)
-	assert.Equal(t, false, sdkClientProtocol.exitProbeOnRegistrationResponseTimeOut)
+	assert.Equal(t, time.Duration(300000000000), sdkClientProtocol.registrationResponseTimeout)
+	assert.Equal(t, false, sdkClientProtocol.restartOnRegistrationTimeout)
+}
+
+func TestCreateSdkClientProtocolHandlerInvalidTimeout(t *testing.T) {
+	communicationBindingChannel := "foo"
+	sdkProtocolConfig := &SdkProtocolConfig{
+		RegistrationTimeoutSec:       10,
+		RestartOnRegistrationTimeout: true,
+	}
+	sdkClientProtocol := CreateSdkClientProtocolHandler(nil, "1.0", communicationBindingChannel, sdkProtocolConfig)
+	assert.Equal(t, time.Duration(300000000000), sdkClientProtocol.registrationResponseTimeout)
+	assert.Equal(t, true, sdkClientProtocol.restartOnRegistrationTimeout)
 }
 
 func TestTimeoutRead(t *testing.T) {

--- a/pkg/mediationcontainer/sdk_client_protocol_test.go
+++ b/pkg/mediationcontainer/sdk_client_protocol_test.go
@@ -41,7 +41,7 @@ func TestTimeoutRead2(t *testing.T) {
 // container info has it.
 func TestCommunicationBindingChannel(t *testing.T) {
 	for _, communicationBindingChannel := range []string{"foo", ""} {
-		sdkClientProtocol := CreateSdkClientProtocolHandler(nil, "1.0", communicationBindingChannel)
+		sdkClientProtocol := CreateSdkClientProtocolHandler(nil, "1.0", communicationBindingChannel, nil)
 		containInfo, err := sdkClientProtocol.MakeContainerInfo()
 		if err != nil {
 			t.Fatalf("Error making container info: %v", err)

--- a/pkg/mediationcontainer/sdk_client_protocol_test.go
+++ b/pkg/mediationcontainer/sdk_client_protocol_test.go
@@ -2,9 +2,17 @@ package mediationcontainer
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
+
+func TestCreateSdkClientProtocolHandler(t *testing.T) {
+	communicationBindingChannel := "foo"
+	sdkClientProtocol := CreateSdkClientProtocolHandler(nil, "1.0", communicationBindingChannel, nil)
+	assert.Equal(t, time.Duration(300000000000), sdkClientProtocol.waitRegistrationResponseTimeOut)
+	assert.Equal(t, false, sdkClientProtocol.exitProbeOnRegistrationResponseTimeOut)
+}
 
 func TestTimeoutRead(t *testing.T) {
 	du := time.Second * 3

--- a/pkg/service/tap_service.go
+++ b/pkg/service/tap_service.go
@@ -198,6 +198,7 @@ func (builder *TAPServiceBuilder) WithTurboCommunicator(commConfig *TurboCommuni
 		ServerMeta:                  commConfig.ServerMeta,
 		WebSocketConfig:             commConfig.WebSocketConfig,
 		CommunicationBindingChannel: builder.tapService.communicationBindingChannel,
+		SdkProtocolConfig:           commConfig.SdkProtocolConfig,
 	}
 	mediationcontainer.CreateMediationContainer(containerConfig)
 

--- a/pkg/service/turbo_communication_config.go
+++ b/pkg/service/turbo_communication_config.go
@@ -32,6 +32,7 @@ type TurboCommunicationConfig struct {
 	mediationcontainer.ServerMeta      `json:"serverMeta,omitempty"`
 	mediationcontainer.WebSocketConfig `json:"websocketConfig,omitempty"`
 	RestAPIConfig                      `json:"restAPIConfig,omitempty"`
+	mediationcontainer.SdkProtocolConfig
 }
 
 func (turboCommConfig *TurboCommunicationConfig) ValidateTurboCommunicationConfig() error {

--- a/pkg/service/turbo_communication_config.go
+++ b/pkg/service/turbo_communication_config.go
@@ -29,10 +29,10 @@ func (rc *RestAPIConfig) ValidRestAPIConfig() error {
 
 // Configuration parameters for communicating with the Turbo server
 type TurboCommunicationConfig struct {
-	mediationcontainer.ServerMeta      `json:"serverMeta,omitempty"`
-	mediationcontainer.WebSocketConfig `json:"websocketConfig,omitempty"`
-	RestAPIConfig                      `json:"restAPIConfig,omitempty"`
-	mediationcontainer.SdkProtocolConfig
+	mediationcontainer.ServerMeta        `json:"serverMeta,omitempty"`
+	mediationcontainer.WebSocketConfig   `json:"websocketConfig,omitempty"`
+	RestAPIConfig                        `json:"restAPIConfig,omitempty"`
+	mediationcontainer.SdkProtocolConfig `json:"sdkProtocolConfig,omitempty"`
 }
 
 func (turboCommConfig *TurboCommunicationConfig) ValidateTurboCommunicationConfig() error {
@@ -44,6 +44,9 @@ func (turboCommConfig *TurboCommunicationConfig) ValidateTurboCommunicationConfi
 		return err
 	}
 	if err := turboCommConfig.ValidRestAPIConfig(); err != nil {
+		return err
+	}
+	if err := turboCommConfig.ValidateSdkProtocolConfig(); err != nil {
 		return err
 	}
 	return nil
@@ -70,7 +73,7 @@ func ParseTurboCommunicationConfig(configFile string) (*TurboCommunicationConfig
 		return nil, err
 	}
 	glog.V(3).Infof("TurboCommunicationConfig Config: %v", turboCommConfig)
-
+	glog.Infof("TurboCommunicationConfig Config: %v", turboCommConfig)
 	if err := turboCommConfig.ValidateTurboCommunicationConfig(); err != nil {
 		return nil, err
 	}

--- a/pkg/service/turbo_communication_config_test.go
+++ b/pkg/service/turbo_communication_config_test.go
@@ -74,8 +74,8 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					APIPath:            rand.String(10),
 				},
 				mediationcontainer.SdkProtocolConfig{
-					RegistrationTimeoutSec: 30,
-					ExitOnProtocolTimeout:  false,
+					RegistrationTimeoutSec:        30,
+					ExitProbePodOnProtocolTimeout: false,
 				},
 			},
 			expectErr: true,
@@ -94,8 +94,8 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					APIPath:            rand.String(10),
 				},
 				mediationcontainer.SdkProtocolConfig{
-					RegistrationTimeoutSec: 30,
-					ExitOnProtocolTimeout:  false,
+					RegistrationTimeoutSec:        30,
+					ExitProbePodOnProtocolTimeout: false,
 				},
 			},
 			expectErr: true,

--- a/pkg/service/turbo_communication_config_test.go
+++ b/pkg/service/turbo_communication_config_test.go
@@ -73,6 +73,10 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					OpsManagerPassword: rand.String(20),
 					APIPath:            rand.String(10),
 				},
+				mediationcontainer.SdkProtocolConfig{
+					RegistrationTimeoutSec: 30,
+					ExitOnProtocolTimeout:  false,
+				},
 			},
 			expectErr: true,
 		},
@@ -88,6 +92,10 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					OpsManagerUsername: rand.String(20),
 					OpsManagerPassword: rand.String(20),
 					APIPath:            rand.String(10),
+				},
+				mediationcontainer.SdkProtocolConfig{
+					RegistrationTimeoutSec: 30,
+					ExitOnProtocolTimeout:  false,
 				},
 			},
 			expectErr: true,

--- a/pkg/service/turbo_communication_config_test.go
+++ b/pkg/service/turbo_communication_config_test.go
@@ -73,10 +73,7 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					OpsManagerPassword: rand.String(20),
 					APIPath:            rand.String(10),
 				},
-				mediationcontainer.SdkProtocolConfig{
-					RegistrationTimeoutSec:       60,
-					RestartOnRegistrationTimeout: false,
-				},
+				mediationcontainer.SdkProtocolConfig{},
 			},
 			expectErr: true,
 		},

--- a/pkg/service/turbo_communication_config_test.go
+++ b/pkg/service/turbo_communication_config_test.go
@@ -74,8 +74,8 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					APIPath:            rand.String(10),
 				},
 				mediationcontainer.SdkProtocolConfig{
-					RegistrationTimeoutSec:        30,
-					ExitProbePodOnProtocolTimeout: false,
+					RegistrationTimeoutSec:       60,
+					RestartOnRegistrationTimeout: false,
 				},
 			},
 			expectErr: true,
@@ -94,8 +94,8 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					APIPath:            rand.String(10),
 				},
 				mediationcontainer.SdkProtocolConfig{
-					RegistrationTimeoutSec:        30,
-					ExitProbePodOnProtocolTimeout: false,
+					RegistrationTimeoutSec:       60,
+					RestartOnRegistrationTimeout: true,
 				},
 			},
 			expectErr: true,
@@ -122,6 +122,27 @@ func TestValidateTurboCommunicationConfig(t *testing.T) {
 					OpsManagerUsername: rand.String(20),
 					OpsManagerPassword: rand.String(20),
 					APIPath:            rand.String(10),
+				},
+				SdkProtocolConfig: mediationcontainer.SdkProtocolConfig{
+					RegistrationTimeoutSec:       60,
+					RestartOnRegistrationTimeout: true,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			config: &TurboCommunicationConfig{
+				ServerMeta: mediationcontainer.ServerMeta{
+					TurboServer: "http:/127.0.0.1",
+				},
+				RestAPIConfig: RestAPIConfig{
+					OpsManagerUsername: rand.String(20),
+					OpsManagerPassword: rand.String(20),
+					APIPath:            rand.String(10),
+				},
+				SdkProtocolConfig: mediationcontainer.SdkProtocolConfig{
+					RegistrationTimeoutSec:       60,
+					RestartOnRegistrationTimeout: false,
 				},
 			},
 			expectErr: false,


### PR DESCRIPTION
- Increase the timeout interval when waiting for response from the server during probe registration process. Default is increased to 300 sec from 30 sec. 
- Also added an option to allow the probe pod to exit if the timeout still occurs during registration. This will allow the Kubernetes system to restart the probe. 
- The registration response wait timeout and the option to exit on timeout are made available as configuration options when configuring the TAP service.

Default Configuration options:
`I0425 21:03:11.668518       1 sdk_client_protocol.go:44] **** SDK Protocol timeout related config [&{RegistrationTimeoutSec:300 ExitOnProtocolTimeout:false}]
`

Logging time taken taken to register the probe:

`I0425 21:03:11.702456       1 sdk_client_protocol.go:136] [NegotiationEndpoint] : Received VersionNegotiation response after 5.136141ms `

`0425 21:03:11.717084       1 sdk_client_protocol.go:192] [RegistrationEndpoint] : Received registration response after 9.885497ms seconds`

```

I0425 21:03:11.668387       1 kubeturbo_builder.go:546] ********** Start running Kubeturbo Service **********
I0425 21:03:11.668491       1 mediation_container.go:67] Initializing mediation container .....
I0425 21:03:11.668501       1 mediation_container.go:74] Registering 1 probes
I0425 21:03:11.668518       1 sdk_client_protocol.go:44] **** SDK Protocol timeout related config [&{RegistrationTimeoutSec:300 ExitOnProtocolTimeout:false}]
I0425 21:03:11.668568       1 client_websocket_transport.go:381] Trying websocket connection to: wss://9.46.99.154/vmturbo/remoteMediation
I0425 21:03:11.696594       1 client_websocket_transport.go:384] Successfully connected to api service at: wss://9.46.99.154/vmturbo/remoteMediation
I0425 21:03:11.696912       1 client_websocket_transport.go:305] Connected to server 9.46.99.154:443::10.129.3.156:52610
I0425 21:03:11.696922       1 client_websocket_transport.go:306] WebSocket transport layer is ready.
I0425 21:03:11.696968       1 remote_mediation_client.go:94] Start sdk client protocol ........
I0425 21:03:11.696984       1 sdk_client_protocol.go:57] Starting protocol negotiation ....
I0425 21:03:11.702456       1 sdk_client_protocol.go:136] [NegotiationEndpoint] : Received VersionNegotiation response after 5.136141ms 
I0425 21:03:11.702530       1 sdk_client_protocol.go:154] Protocol negotiation result: ACCEPTED. Protocol version "8.8.5" is allowed to interact with server.
I0425 21:03:11.702549       1 sdk_client_protocol.go:66] Starting probe registration ....
I0425 21:03:11.702558       1 sdk_client_protocol.go:211] SdkClientProtocol] Creating Probe Info for Kubernetes
I0425 21:03:11.702824       1 registration_client.go:211] Begin to build Action Merge Policies
I0425 21:03:11.702879       1 registration_client.go:295] Begin to build default secure probe target
I0425 21:03:11.717084       1 sdk_client_protocol.go:192] [RegistrationEndpoint] : Received registration response after 9.885497ms seconds
I0425 21:03:11.717143       1 sdk_client_protocol.go:203] Probe registration succeeded.




```

Parameters are exposed via the TurboCommunication config file.

```
"communicationConfig": {
             "serverMeta": {
                  "version" : "8.8.6",
                  "turboServer": "https://9.46.99.154"
             },
             "restAPIConfig": {
                "opsManagerUserName": "administrator",
                "opsManagerPassword": "admin"
             },
             "sdkProtocolConfig": {
                "registrationTimeoutSec": 600
                "restartOnRegistrationTimeout": true
             }
        },
```
If this config is not provided , default values are:
 ```
"sdkProtocolConfig": {
                "registrationTimeoutSec": 300
                "restartOnRegistrationTimeout": false
             }
```