### PR TITLE
[OM-100967]:  add guard for NPE in websocket write method

### DIFF
--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -150,9 +150,7 @@ func (wsTransport *ClientWebSocketTransport) write(mtype int, payload []byte) er
 	if ws == nil {
 		return errors.New("websocket connection unavailable")
 	}
-	if err := ws.SetWriteDeadline(time.Now().Add(writeWaitTimeout)); err != nil {
-		return err
-	}
+	ws.SetWriteDeadline(time.Now().Add(writeWaitTimeout))
 	return ws.WriteMessage(mtype, payload)
 }
 

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -145,8 +145,15 @@ func (wsTransport *ClientWebSocketTransport) closeAndResetWebSocket() {
 func (wsTransport *ClientWebSocketTransport) write(mtype int, payload []byte) error {
 	wsTransport.wsMux.Lock()
 	defer wsTransport.wsMux.Unlock()
-	wsTransport.ws.SetWriteDeadline(time.Now().Add(writeWaitTimeout))
-	return wsTransport.ws.WriteMessage(mtype, payload)
+
+	ws := wsTransport.ws
+	if ws == nil {
+		return errors.New("websocket connection unavailable")
+	}
+	if err := ws.SetWriteDeadline(time.Now().Add(writeWaitTimeout)); err != nil {
+		return err
+	}
+	return ws.WriteMessage(mtype, payload)
 }
 
 // keep sending Ping msg to make sure the websocket connection is alive

--- a/pkg/mediationcontainer/client_websocket_transport.go
+++ b/pkg/mediationcontainer/client_websocket_transport.go
@@ -142,6 +142,8 @@ func (wsTransport *ClientWebSocketTransport) closeAndResetWebSocket() {
 	wsTransport.status = Closed
 }
 
+// write sends a WebSocket message with the given type and payload data.
+// It returns an error if the WebSocket connection is unavailable or the write operation fails.
 func (wsTransport *ClientWebSocketTransport) write(mtype int, payload []byte) error {
 	wsTransport.wsMux.Lock()
 	defer wsTransport.wsMux.Unlock()


### PR DESCRIPTION
kubeturbo (8.8.4) crashed when losing its connection to the cluster in Netskope early access tests.
The stack trace showing a NPE in the routine of pinging when monitoring the websocket connection:

```
I0419 20:26:12.754521       1 remote_mediation_client.go:115] [Reconnect] transport endpoint is closed, starting reconnect ...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x1b5e9a1]

goroutine 1262 [running]:
[github.com/gorilla/websocket.(*Conn).SetWriteDeadline(..](https://urldefense.proofpoint.com/v2/url?u=http-3A__github.com_gorilla_websocket.-28-2AConn-29.SetWriteDeadline-28..&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=ChEuJySc-ouWcdrXhCMSRckTpW_l-2QwdxCR6xijptg&m=9Y_Zk0ooIh6-HdSQswb6orZZOC17oQaEFjgIbBKoH2qsuVaNQgbTQyB8QLpVwcvo&s=2a5DIeTu_PeG1TrFRBz-JXI0NQ_2f4GjzErKkg1vjx0&e=).)
/home/jenkins/workspace/xl-8.8.4-kubeturbo-build/src/[github.com/turbonomic/kubeturbo/vendor/github.com/gorilla/websocket/conn.go:781](https://urldefense.proofpoint.com/v2/url?u=http-3A__github.com_turbonomic_kubeturbo_vendor_github.com_gorilla_websocket_conn.go-3A781&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=ChEuJySc-ouWcdrXhCMSRckTpW_l-2QwdxCR6xijptg&m=9Y_Zk0ooIh6-HdSQswb6orZZOC17oQaEFjgIbBKoH2qsuVaNQgbTQyB8QLpVwcvo&s=tb9V3vbts21FXFsnvPoOnfabQHqagenm2lIHPZ6yijg&e=)
[github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*ClientWebSocketTransport).write(0xc000133e60](https://urldefense.proofpoint.com/v2/url?u=http-3A__github.com_turbonomic_turbo-2Dgo-2Dsdk_pkg_mediationcontainer.-28-2AClientWebSocketTransport-29.write-280xc000133e60&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=ChEuJySc-ouWcdrXhCMSRckTpW_l-2QwdxCR6xijptg&m=9Y_Zk0ooIh6-HdSQswb6orZZOC17oQaEFjgIbBKoH2qsuVaNQgbTQyB8QLpVwcvo&s=u9NZKDH6PVAxpE6M17Ic8fHNATbM-qQhxtrxx4Qofzg&e=), 0xc000acdf60?, {0x374e848, 0x0, 0x0})
/home/jenkins/workspace/xl-8.8.4-kubeturbo-build/src/[github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go:148](https://urldefense.proofpoint.com/v2/url?u=http-3A__github.com_turbonomic_kubeturbo_vendor_github.com_turbonomic_turbo-2Dgo-2Dsdk_pkg_mediationcontainer_client-5Fwebsocket-5Ftransport.go-3A148&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=ChEuJySc-ouWcdrXhCMSRckTpW_l-2QwdxCR6xijptg&m=9Y_Zk0ooIh6-HdSQswb6orZZOC17oQaEFjgIbBKoH2qsuVaNQgbTQyB8QLpVwcvo&s=FVcoeO37o4zzmuCIyL6kgwErfcjmGH9EyzJFSeiu8Qk&e=) +0xc1
[github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*ClientWebSocketTransport).startPing(0xc000133e60)](https://urldefense.proofpoint.com/v2/url?u=http-3A__github.com_turbonomic_turbo-2Dgo-2Dsdk_pkg_mediationcontainer.-28-2AClientWebSocketTransport-29.startPing-280xc000133e60-29&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=ChEuJySc-ouWcdrXhCMSRckTpW_l-2QwdxCR6xijptg&m=9Y_Zk0ooIh6-HdSQswb6orZZOC17oQaEFjgIbBKoH2qsuVaNQgbTQyB8QLpVwcvo&s=ffGaM11-RMvj_-8FysTe95wC3dmRT17xQcdGrFo9WYc&e=)
/home/jenkins/workspace/xl-8.8.4-kubeturbo-build/src/[github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go:166](https://urldefense.proofpoint.com/v2/url?u=http-3A__github.com_turbonomic_kubeturbo_vendor_github.com_turbonomic_turbo-2Dgo-2Dsdk_pkg_mediationcontainer_client-5Fwebsocket-5Ftransport.go-3A166&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=ChEuJySc-ouWcdrXhCMSRckTpW_l-2QwdxCR6xijptg&m=9Y_Zk0ooIh6-HdSQswb6orZZOC17oQaEFjgIbBKoH2qsuVaNQgbTQyB8QLpVwcvo&s=CCnnCxwtjDd4HnyYQyw-ykWtmNg3FwCyprfFLOXzysg&e=) +0x129
created by [github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer.(*ClientWebSocketTransport).Connect](https://urldefense.proofpoint.com/v2/url?u=http-3A__github.com_turbonomic_turbo-2Dgo-2Dsdk_pkg_mediationcontainer.-28-2AClientWebSocketTransport-29.Connect&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=ChEuJySc-ouWcdrXhCMSRckTpW_l-2QwdxCR6xijptg&m=9Y_Zk0ooIh6-HdSQswb6orZZOC17oQaEFjgIbBKoH2qsuVaNQgbTQyB8QLpVwcvo&s=TKpDPEF1ZSc5GousKN25nzceDMfOXFKXmiBinPQg6aY&e=)
/home/jenkins/workspace/xl-8.8.4-kubeturbo-build/src/[github.com/turbonomic/kubeturbo/vendor/github.com/turbonomic/turbo-go-sdk/pkg/mediationcontainer/client_websocket_transport.go:96](https://urldefense.proofpoint.com/v2/url?u=http-3A__github.com_turbonomic_kubeturbo_vendor_github.com_turbonomic_turbo-2Dgo-2Dsdk_pkg_mediationcontainer_client-5Fwebsocket-5Ftransport.go-3A96&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=ChEuJySc-ouWcdrXhCMSRckTpW_l-2QwdxCR6xijptg&m=9Y_Zk0ooIh6-HdSQswb6orZZOC17oQaEFjgIbBKoH2qsuVaNQgbTQyB8QLpVwcvo&s=_MzbKK_6RvsY-XGkHwak_dES4jQcbK8UzEWMEoDdCIY&e=) +0x1af
```
I do not see the locking issue in this work flow. The line 148 showing below need a check to guard against issue causing the NPE showing in the log. It is possible that the WebSocket connection could become invalid or disconnected for other reasons, even if the transport status is not "Closed".

Also we need to check for [wsTransport.ws](http://wstransport.ws/).SetWriteDeadline. This can return error as well.
```
The SetWriteDeadline method is a method of the *websocket.Conn type, which is defined in the gorilla/websocket package. The method has the following signature:
go

func (c *Conn) SetWriteDeadline(t time.Time) error 
```

Modified code compiled successfully with both test and checkstyle enabled.
