### PR TITLE
[TRB-23205]: Filter out duplicate commodities

### DIFF
--- a/pkg/builder/entity_dto_builder.go
+++ b/pkg/builder/entity_dto_builder.go
@@ -221,12 +221,35 @@ func (eb *EntityDTOBuilder) DisplayName(displayName string) *EntityDTOBuilder {
 	return eb
 }
 
+// remove duplicate commodities from the given commodity list
+func PurifyCommodities(commDTOs []*proto.CommodityDTO) []*proto.CommodityDTO {
+	commodityMap := make(map[string]*proto.CommodityDTO)
+	for _, commodity := range commDTOs {
+		mapKey := string(*commodity.CommodityType)
+		if commodity.Key != nil {
+			mapKey = mapKey + "_" + string(*commodity.Key)
+		}
+
+		if _, found := commodityMap[mapKey]; !found {
+			commodityMap[mapKey] = commodity
+		}
+	}
+
+	filteredCommodities := []*proto.CommodityDTO{}
+	for _, commodity := range commodityMap {
+		filteredCommodities = append(filteredCommodities, commodity)
+	}
+
+	return filteredCommodities
+}
+
 // Add a list of commodities to entity commodities sold list.
 func (eb *EntityDTOBuilder) SellsCommodities(commDTOs []*proto.CommodityDTO) *EntityDTOBuilder {
 	if eb.err != nil {
 		return eb
 	}
-	eb.commoditiesSold = append(eb.commoditiesSold, commDTOs...)
+	newCommoditiesSold := append(eb.commoditiesSold, commDTOs...)
+	eb.commoditiesSold = PurifyCommodities(newCommoditiesSold)
 	return eb
 }
 
@@ -238,7 +261,8 @@ func (eb *EntityDTOBuilder) SellsCommodity(commDTO *proto.CommodityDTO) *EntityD
 	if eb.commoditiesSold == nil {
 		eb.commoditiesSold = []*proto.CommodityDTO{}
 	}
-	eb.commoditiesSold = append(eb.commoditiesSold, commDTO)
+	newCommoditiesSold := append(eb.commoditiesSold, commDTO)
+	eb.commoditiesSold = PurifyCommodities(newCommoditiesSold)
 	return eb
 }
 
@@ -288,7 +312,7 @@ func (eb *EntityDTOBuilder) BuysCommodity(commDTO *proto.CommodityDTO) *EntityDT
 		commoditiesSoldByCurrentProvider = []*proto.CommodityDTO{}
 	}
 	commoditiesSoldByCurrentProvider = append(commoditiesSoldByCurrentProvider, commDTO)
-	eb.commoditiesBoughtProviderMap[eb.currentProvider.id] = commoditiesSoldByCurrentProvider
+	eb.commoditiesBoughtProviderMap[eb.currentProvider.id] = PurifyCommodities(commoditiesSoldByCurrentProvider)
 
 	return eb
 }

--- a/pkg/builder/entity_dto_builder.go
+++ b/pkg/builder/entity_dto_builder.go
@@ -222,10 +222,10 @@ func (eb *EntityDTOBuilder) DisplayName(displayName string) *EntityDTOBuilder {
 }
 
 // remove duplicate commodities from the given commodity list
-func PurifyCommodities(commDTOs []*proto.CommodityDTO) []*proto.CommodityDTO {
+func removeDuplicatedCommodities(commDTOs []*proto.CommodityDTO) []*proto.CommodityDTO {
 	commodityMap := make(map[string]*proto.CommodityDTO)
 	for _, commodity := range commDTOs {
-		mapKey := "undifined"
+		mapKey := "Undefined"
 		if commodity.CommodityType != nil {
 			mapKey = string(*commodity.CommodityType)
 		}
@@ -249,7 +249,7 @@ func (eb *EntityDTOBuilder) SellsCommodities(commDTOs []*proto.CommodityDTO) *En
 		return eb
 	}
 	newCommoditiesSold := append(eb.commoditiesSold, commDTOs...)
-	eb.commoditiesSold = PurifyCommodities(newCommoditiesSold)
+	eb.commoditiesSold = removeDuplicatedCommodities(newCommoditiesSold)
 	return eb
 }
 
@@ -262,7 +262,7 @@ func (eb *EntityDTOBuilder) SellsCommodity(commDTO *proto.CommodityDTO) *EntityD
 		eb.commoditiesSold = []*proto.CommodityDTO{}
 	}
 	newCommoditiesSold := append(eb.commoditiesSold, commDTO)
-	eb.commoditiesSold = PurifyCommodities(newCommoditiesSold)
+	eb.commoditiesSold = removeDuplicatedCommodities(newCommoditiesSold)
 	return eb
 }
 
@@ -312,7 +312,7 @@ func (eb *EntityDTOBuilder) BuysCommodity(commDTO *proto.CommodityDTO) *EntityDT
 		commoditiesSoldByCurrentProvider = []*proto.CommodityDTO{}
 	}
 	commoditiesSoldByCurrentProvider = append(commoditiesSoldByCurrentProvider, commDTO)
-	eb.commoditiesBoughtProviderMap[eb.currentProvider.id] = PurifyCommodities(commoditiesSoldByCurrentProvider)
+	eb.commoditiesBoughtProviderMap[eb.currentProvider.id] = removeDuplicatedCommodities(commoditiesSoldByCurrentProvider)
 
 	return eb
 }

--- a/pkg/builder/entity_dto_builder.go
+++ b/pkg/builder/entity_dto_builder.go
@@ -225,14 +225,14 @@ func (eb *EntityDTOBuilder) DisplayName(displayName string) *EntityDTOBuilder {
 func PurifyCommodities(commDTOs []*proto.CommodityDTO) []*proto.CommodityDTO {
 	commodityMap := make(map[string]*proto.CommodityDTO)
 	for _, commodity := range commDTOs {
-		mapKey := string(*commodity.CommodityType)
+		mapKey := "undifined"
+		if commodity.CommodityType != nil {
+			mapKey = string(*commodity.CommodityType)
+		}
 		if commodity.Key != nil {
 			mapKey = mapKey + "_" + string(*commodity.Key)
 		}
-
-		if _, found := commodityMap[mapKey]; !found {
-			commodityMap[mapKey] = commodity
-		}
+		commodityMap[mapKey] = commodity
 	}
 
 	filteredCommodities := []*proto.CommodityDTO{}

--- a/pkg/builder/entity_dto_builder_test.go
+++ b/pkg/builder/entity_dto_builder_test.go
@@ -166,12 +166,6 @@ func TestEntityDTOBuilder_SellsCommodities(t *testing.T) {
 			base.err = item.err
 		}
 		builder := base.SellsCommodities(item.commDTOs)
-		// append commodities twice to DTO to verify if duplicate commodities scenario occurs
-		expectedCommoditiesSold := len(builder.commoditiesSold)
-		builder = base.SellsCommodities(item.commDTOs)
-		if len(builder.commoditiesSold) != expectedCommoditiesSold {
-			t.Errorf("\nDuplicated commodities found in commoditiesSold")
-		}
 		expectedBuilder := &EntityDTOBuilder{
 			entityType:        base.entityType,
 			id:                base.id,
@@ -182,6 +176,12 @@ func TestEntityDTOBuilder_SellsCommodities(t *testing.T) {
 		}
 		if !reflect.DeepEqual(expectedBuilder, builder) {
 			t.Errorf("\nExpected: %++v, \ngot %++v", expectedBuilder, builder)
+		}
+		// append commodities twice to DTO to verify if duplicate commodities scenario occurs
+		expectedCommoditiesSold := len(builder.commoditiesSold)
+		builder = base.SellsCommodities(item.commDTOs)
+		if len(builder.commoditiesSold) != expectedCommoditiesSold {
+			t.Errorf("\nDuplicated commodities found in commoditiesSold")
 		}
 	}
 }
@@ -205,12 +205,6 @@ func TestEntityDTOBuilder_SellsCommodity(t *testing.T) {
 			base.err = item.err
 		}
 		builder := base.SellsCommodity(item.commDTO)
-		// append a commodity twice to DTO to verify if duplicate commodities scenario occurs
-		expectedCommoditiesSold := len(builder.commoditiesSold)
-		builder = base.SellsCommodity(item.commDTO)
-		if len(builder.commoditiesSold) != expectedCommoditiesSold {
-			t.Errorf("\nDuplicated commodities found in commoditiesSold")
-		}
 		var comms []*proto.CommodityDTO
 		if item.commDTO != nil {
 			comms = append(comms, item.commDTO)
@@ -225,6 +219,12 @@ func TestEntityDTOBuilder_SellsCommodity(t *testing.T) {
 		}
 		if !reflect.DeepEqual(expectedBuilder, builder) {
 			t.Errorf("\nExpected:\n %++v, \ngot\n %++v", expectedBuilder, builder)
+		}
+		// append a commodity twice to DTO to verify if duplicate commodities scenario occurs
+		expectedCommoditiesSold := len(builder.commoditiesSold)
+		builder = base.SellsCommodity(item.commDTO)
+		if len(builder.commoditiesSold) != expectedCommoditiesSold {
+			t.Errorf("\nDuplicated commodities found in commoditiesSold")
 		}
 	}
 }

--- a/pkg/builder/entity_dto_builder_test.go
+++ b/pkg/builder/entity_dto_builder_test.go
@@ -166,6 +166,12 @@ func TestEntityDTOBuilder_SellsCommodities(t *testing.T) {
 			base.err = item.err
 		}
 		builder := base.SellsCommodities(item.commDTOs)
+		// append commodities twice to DTO to verify if duplicate commodities scenario occurs
+		expectedCommoditiesSold := len(builder.commoditiesSold)
+		builder = base.SellsCommodities(item.commDTOs)
+		if len(builder.commoditiesSold) != expectedCommoditiesSold {
+			t.Errorf("\nDuplicated commodities found in commoditiesSold")
+		}
 		expectedBuilder := &EntityDTOBuilder{
 			entityType:        base.entityType,
 			id:                base.id,
@@ -199,6 +205,12 @@ func TestEntityDTOBuilder_SellsCommodity(t *testing.T) {
 			base.err = item.err
 		}
 		builder := base.SellsCommodity(item.commDTO)
+		// append a commodity twice to DTO to verify if duplicate commodities scenario occurs
+		expectedCommoditiesSold := len(builder.commoditiesSold)
+		builder = base.SellsCommodity(item.commDTO)
+		if len(builder.commoditiesSold) != expectedCommoditiesSold {
+			t.Errorf("\nDuplicated commodities found in commoditiesSold")
+		}
 		var comms []*proto.CommodityDTO
 		if item.commDTO != nil {
 			comms = append(comms, item.commDTO)


### PR DESCRIPTION
# Intent
Filter out duplicated commodities that have the same commodity type and the key from the entity DTO objects.

# Implementation

- Adding filter implementation to prevent appending duplicated sold commodities to the sold commodity list
- Adding logic to prevent appending existing sold commodities to the sold commodity list
- Adding logic to prevent appending existing buy commodities to the buy commodity list
