### PR TITLE
[TRB-46807]: Removed coveralls integration from travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.16
+  - 1.20.7
 
 go_import_path: github.com/turbonomic/turbo-go-sdk
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ go:
 
 go_import_path: github.com/turbonomic/turbo-go-sdk
 
-before_install:
-  - go get -v github.com/mattn/goveralls
-
 script:
   - make fmtcheck 
-  - if [ "$TRAVIS_GO_VERSION" == "tip" ] ; then make test ; else $HOME/gopath/bin/goveralls -v -race -service=travis-ci -ignore="pkg/proto/*" ; fi
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 
 .PHONY: fmtcheck
 fmtcheck:
-	@gofmt -l $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
+	@gofmt -l $(SOURCE_DIRS) | grep ".*\.go" | grep -v "pkg/version/version.pb.go"; if [ "$$?" = "0" ]; then exit 1; fi
 
 .PHONY: vet
 vet:

--- a/pkg/builder/group/policy_builder.go
+++ b/pkg/builder/group/policy_builder.go
@@ -2,6 +2,7 @@ package group
 
 import (
 	"fmt"
+
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
 )
 
@@ -179,7 +180,7 @@ func (doNotPlaceTogether *DoNotPlaceTogetherPolicyBuilder) Build() ([]*proto.Gro
 	return buildBuyerBuyerPolicyGroup(doNotPlaceTogether.buyerBuyerPolicyData)
 }
 
-////========================================================================
+// //========================================================================
 func buildBuyerSellerPolicyGroup(policyData *buyerSellerPolicyData) ([]*proto.GroupDTO, error) {
 	if policyData.buyerData == nil {
 		return nil, fmt.Errorf("[buildBuyerSellerPolicyGroup] Buyer group data not set")

--- a/pkg/builder/merged_entity_meta_data_builder.go
+++ b/pkg/builder/merged_entity_meta_data_builder.go
@@ -24,6 +24,7 @@ type matchingData struct {
 // In some cases, we encode a List of Strings as a single string.
 // In that case, one can specify a delimiter that separates different strings in the value.
 // For example, we have a PM_UUID_LIST property where we have a comma separated list of UUIDs in a single string.
+//
 //	message MatchingData {
 //		oneof matching_data {
 //			EntityPropertyName matching_property = 100;
@@ -305,14 +306,15 @@ func (builder *MergedEntityMetadataBuilder) KeepInTopology(keepInTopology bool) 
 
 // WithMergePropertiesStrategy defines the merge strategy for properties for stitched entities. We currntly support
 // the following strategies:
-//   1. MERGE_NOTHING: properties of the "onto" entity are preserved and no property merging is applied. This
-//      strategy should be used when we know for sure that all targets discover the same set of properties for
-//      each shared entity.
-//   2. MERGE_IF_NOT_PRESENT: the resulting property list is a union of all properties from all EntityDTOs. When a
-//      property exists in both the "from" and "onto" entities, the "onto" entity values will be preserved.
-//   3. MERGE_AND_OVERWRITE: The resulting property list is a union of all properties from all EntityDTOs. When a
-//      property exists in both the "from" and "onto" entities, the "from" entity values will overwrite those
-//      of the "onto" entity.
+//  1. MERGE_NOTHING: properties of the "onto" entity are preserved and no property merging is applied. This
+//     strategy should be used when we know for sure that all targets discover the same set of properties for
+//     each shared entity.
+//  2. MERGE_IF_NOT_PRESENT: the resulting property list is a union of all properties from all EntityDTOs. When a
+//     property exists in both the "from" and "onto" entities, the "onto" entity values will be preserved.
+//  3. MERGE_AND_OVERWRITE: The resulting property list is a union of all properties from all EntityDTOs. When a
+//     property exists in both the "from" and "onto" entities, the "from" entity values will overwrite those
+//     of the "onto" entity.
+//
 // By default, the MERGE_NOTHING merge strategy is used.
 func (builder *MergedEntityMetadataBuilder) WithMergePropertiesStrategy(mergePropertiesStrategy proto.MergedEntityMetadata_MergePropertiesStrategy) *MergedEntityMetadataBuilder {
 	builder.mergePropertiesStrategy = mergePropertiesStrategy

--- a/pkg/builder/replacement_entity_meta_data_builder.go
+++ b/pkg/builder/replacement_entity_meta_data_builder.go
@@ -68,7 +68,8 @@ func (builder *ReplacementEntityMetaDataBuilder) PatchBuyingWithProperty(commTyp
 }
 
 // Set the commodity type whose metric values will be transferred to the entity
-//  builder DTO will be replaced by.
+//
+//	builder DTO will be replaced by.
 func (builder *ReplacementEntityMetaDataBuilder) PatchSelling(commType proto.CommodityDTO_CommodityType) *ReplacementEntityMetaDataBuilder {
 	return builder.PatchSellingWithProperty(commType, defaultPropertyNames)
 }

--- a/pkg/dataingestionframework/data/dif_topology.go
+++ b/pkg/dataingestionframework/data/dif_topology.go
@@ -2,7 +2,7 @@ package data
 
 import "time"
 
-//Data injection framework topology
+// Data injection framework topology
 type Topology struct {
 	Version    string       `json:"version"`
 	Updatetime int64        `json:"updateTime"`

--- a/pkg/dataingestionframework/data/dif_types.go
+++ b/pkg/dataingestionframework/data/dif_types.go
@@ -2,10 +2,11 @@ package data
 
 import (
 	"fmt"
+
 	set "github.com/deckarep/golang-set"
 )
 
-//Data ingestion framework topology entity
+// Data ingestion framework topology entity
 type DIFEntity struct {
 	UID                 string                     `json:"uniqueId"`
 	Type                string                     `json:"type"`
@@ -115,26 +116,28 @@ func (e *DIFEntity) Matching(id string) *DIFEntity {
 	return e
 }
 
-/**
- Add a metric with certain type, kind, value and key to the DIF entity.
- This function makes it easier to add a metric of the same type (e.g., memory) but
- different kind (e.g., average, or capacity) to a DIF entity, because they can be
- discovered at different times.
- The DIFEntity.Metrics is a map where the key is the metric type, and the value is
- a list of DIFMetricVal. We need a list of DIFMetricVal to hold metrics with the same
- type but different keys, for example:
-	kpi: [
-		{
-			average: 123,
-			capacity: 1000,
-			key: "total_messages_in_queue"
-		},
-		{
-			average: 104.44444444444444,
-			capacity: 1000,
-			key: "total_waiting_time_in_queue"
-		}
-	],
+/*
+*
+
+	 Add a metric with certain type, kind, value and key to the DIF entity.
+	 This function makes it easier to add a metric of the same type (e.g., memory) but
+	 different kind (e.g., average, or capacity) to a DIF entity, because they can be
+	 discovered at different times.
+	 The DIFEntity.Metrics is a map where the key is the metric type, and the value is
+	 a list of DIFMetricVal. We need a list of DIFMetricVal to hold metrics with the same
+	 type but different keys, for example:
+		kpi: [
+			{
+				average: 123,
+				capacity: 1000,
+				key: "total_messages_in_queue"
+			},
+			{
+				average: 104.44444444444444,
+				capacity: 1000,
+				key: "total_waiting_time_in_queue"
+			}
+		],
 */
 func (e *DIFEntity) AddMetric(metricType string, kind DIFMetricValKind, value float64, key string) {
 	var metricVal *DIFMetricVal


### PR DESCRIPTION
# Intent

Remove coveralls integrations from Travis builds.

# Background

Coveralls is free for public repositories, but requires licenses for private/enterprise repos. Since we are moving to IBM enterprise Git, we need to remove this integration. We should be able to capture code coverage using SonarQube, or some other approved, tool in the future. 

# Testing

N/A - will test enterprise build after merging.